### PR TITLE
accessing and reading content controls

### DIFF
--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -7,6 +7,7 @@ ones like structured document tags.
 """
 
 from __future__ import absolute_import, print_function
+from collections import OrderedDict
 
 from .oxml.table import CT_Tbl
 from .shared import Parented
@@ -61,11 +62,18 @@ class BlockItemContainer(Parented):
     @property
     def sdts(self):
         """
-        A list content controls in this container, in document order.
-        Read-only.
+        A list of children sdts (content controls) in this container, in
+        document order. Read-only.
         """
-        import pdb; pdb.set_trace()
-        return [SdtBase(s, self) for s in self._element.sdt_lst]
+        return OrderedDict({k:SdtBase(s, self) for (s,k) in self._element.sdts})
+
+    @property
+    def sdts_all(self):
+        """
+        A list of descendants sdts (content controls) in this container, in
+        document order. Read-only.
+        """
+        return OrderedDict({k:SdtBase(s, self) for (s,k) in self._element.sdts_all})
 
     @property
     def tables(self):

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, print_function
 from .oxml.table import CT_Tbl
 from .shared import Parented
 from .text.paragraph import Paragraph
+from .sdt import SdtBase
 
 
 class BlockItemContainer(Parented):
@@ -56,6 +57,15 @@ class BlockItemContainer(Parented):
         order. Read-only.
         """
         return [Paragraph(p, self) for p in self._element.p_lst]
+
+    @property
+    def sdts(self):
+        """
+        A list content controls in this container, in document order.
+        Read-only.
+        """
+        import pdb; pdb.set_trace()
+        return [SdtBase(s, self) for s in self._element.sdt_lst]
 
     @property
     def tables(self):

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -65,7 +65,7 @@ class BlockItemContainer(Parented):
         A list of children sdts (content controls) in this container, in
         document order. Read-only.
         """
-        return OrderedDict({k:SdtBase(s, self) for (s,k) in self._element.sdts})
+        return OrderedDict({k:SdtBase(s, self) for (s,k) in self._element.iter_sdts()})
 
     @property
     def sdts_all(self):
@@ -73,7 +73,7 @@ class BlockItemContainer(Parented):
         A list of descendants sdts (content controls) in this container, in
         document order. Read-only.
         """
-        return OrderedDict({k:SdtBase(s, self) for (s,k) in self._element.sdts_all})
+        return OrderedDict({k:SdtBase(s, self) for (s,k) in self._element.iter_sdts_all()})
 
     @property
     def tables(self):

--- a/docx/document.py
+++ b/docx/document.py
@@ -167,9 +167,16 @@ class Document(ElementProxy):
     @property
     def sdts(self):
         """
-        A list of |SdtBlock| instances in this document.
+        A list of |SdtBase| children instances in this document.
         """
         return self._body.sdts
+
+    @property
+    def sdts_all(self):
+        """
+        A list of |SdtBase| descendants instances in this document.
+        """
+        return self._body.sdts_all
 
     @property
     def tables(self):

--- a/docx/document.py
+++ b/docx/document.py
@@ -165,6 +165,13 @@ class Document(ElementProxy):
         return self._part.styles
 
     @property
+    def sdts(self):
+        """
+        A list of |SdtBlock| instances in this document.
+        """
+        return self._body.sdts
+
+    @property
     def tables(self):
         """
         A list of |Table| instances corresponding to the tables in the

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -196,7 +196,11 @@ register_element_cls('w:tab',             CT_TabStop)
 register_element_cls('w:tabs',            CT_TabStops)
 register_element_cls('w:widowControl',    CT_OnOff)
 
-from .text.run import CT_Br, CT_R, CT_Text
-register_element_cls('w:br', CT_Br)
-register_element_cls('w:r',  CT_R)
-register_element_cls('w:t',  CT_Text)
+from .text.run import (
+    CT_Br, CT_R, CT_Text, CT_SdtRun, CT_SdtContentRun
+)
+register_element_cls('w:br',         CT_Br)
+register_element_cls('w:r',          CT_R)
+register_element_cls('w:t',          CT_Text)
+register_element_cls('w:sdt',        CT_SdtRun)
+register_element_cls('w:sdtContent', CT_SdtContentRun)

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -145,6 +145,10 @@ register_element_cls('w:tcW',        CT_TblWidth)
 register_element_cls('w:tr',         CT_Row)
 register_element_cls('w:vMerge',     CT_VMerge)
 
+from .sdts import CT_SdtBase, CT_SdtContentBase
+register_element_cls('w:sdt',        CT_SdtBase)
+register_element_cls('w:sdtContent', CT_SdtContentBase)
+
 from .text.font import (
     CT_Color, CT_Fonts, CT_Highlight, CT_HpsMeasure, CT_RPr, CT_Underline,
     CT_VerticalAlignRun
@@ -196,11 +200,7 @@ register_element_cls('w:tab',             CT_TabStop)
 register_element_cls('w:tabs',            CT_TabStops)
 register_element_cls('w:widowControl',    CT_OnOff)
 
-from .text.run import (
-    CT_Br, CT_R, CT_Text, CT_SdtRun, CT_SdtContentRun
-)
-register_element_cls('w:br',         CT_Br)
-register_element_cls('w:r',          CT_R)
-register_element_cls('w:t',          CT_Text)
-register_element_cls('w:sdt',        CT_SdtRun)
-register_element_cls('w:sdtContent', CT_SdtContentRun)
+from .text.run import CT_Br, CT_R, CT_Text
+register_element_cls('w:br', CT_Br)
+register_element_cls('w:r',  CT_R)
+register_element_cls('w:t',  CT_Text)

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -145,8 +145,11 @@ register_element_cls('w:tcW',        CT_TblWidth)
 register_element_cls('w:tr',         CT_Row)
 register_element_cls('w:vMerge',     CT_VMerge)
 
-from .sdts import CT_SdtBase, CT_SdtContentBase
+from .sdts import (
+    CT_SdtBase, CT_SdtPr, CT_SdtContentBase
+)
 register_element_cls('w:sdt',        CT_SdtBase)
+register_element_cls('w:sdtPr',      CT_SdtPr)
 register_element_cls('w:sdtContent', CT_SdtContentBase)
 
 from .text.font import (

--- a/docx/oxml/document.py
+++ b/docx/oxml/document.py
@@ -60,12 +60,10 @@ class CT_Body(BaseOxmlElement):
         for content_elm in content_elms:
             self.remove(content_elm)
 
-    @property
-    def sdts(self):
+    def iter_sdts(self):
         for sdt in self.sdt_lst:
             yield sdt, sdt.name
 
-    @property
-    def sdts_all(self):
+    def iter_sdts_all(self):
         for sdt in self.iterdescendants('{%s}sdt' % nsmap['w']):
             yield sdt, sdt.name

--- a/docx/oxml/document.py
+++ b/docx/oxml/document.py
@@ -6,6 +6,7 @@ Custom element classes that correspond to the document part, e.g.
 """
 
 from .xmlchemy import BaseOxmlElement, ZeroOrOne, ZeroOrMore
+from .ns import qn, nsmap
 
 
 class CT_Document(BaseOxmlElement):
@@ -58,3 +59,13 @@ class CT_Body(BaseOxmlElement):
             content_elms = self[:]
         for content_elm in content_elms:
             self.remove(content_elm)
+
+    @property
+    def sdts(self):
+        for sdt in self.sdt_lst:
+            yield sdt, sdt.name
+
+    @property
+    def sdts_all(self):
+        for sdt in self.iterdescendants('{%s}sdt' % nsmap['w']):
+            yield sdt, sdt.name

--- a/docx/oxml/document.py
+++ b/docx/oxml/document.py
@@ -28,6 +28,7 @@ class CT_Body(BaseOxmlElement):
     ``<w:body>``, the container element for the main document story in
     ``document.xml``.
     """
+    sdt = ZeroOrMore('w:sdt', successors=('w:p',))
     p = ZeroOrMore('w:p', successors=('w:sectPr',))
     tbl = ZeroOrMore('w:tbl', successors=('w:sectPr',))
     sectPr = ZeroOrOne('w:sectPr', successors=())

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -8,7 +8,7 @@ all occurrences of `w:sdt` within the document.
 """
 
 from .xmlchemy import BaseOxmlElement, ZeroOrOne, ZeroOrMore
-from .ns import nsmap
+from .ns import nsmap, qn
 
 class CT_SdtBase(BaseOxmlElement):
     """
@@ -49,3 +49,12 @@ class CT_SdtContentBase(BaseOxmlElement):
     It contains all paragraphs within the content control.
     """
     p = ZeroOrMore('w:p')
+
+    def get_runs(self):
+        def walk(el):
+            for child in el:
+                if child.tag == qn('w:r'):
+                    yield child
+                else:
+                    yield from walk(child)
+        yield from walk(self)

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -1,0 +1,36 @@
+"""
+Custom element classes that represent content control
+elements within the document part.
+"""
+
+from .xmlchemy import BaseOxmlElement, ZeroOrOne, ZeroOrMore
+from .ns import qn
+
+class CT_SdtBase(BaseOxmlElement):
+    """
+    ``<w:sdt>`` structured document tag element specifying
+    a content control elements.
+    """
+    _tag_seq = ('w:sdtPr', 'w:stEndPr', 'w:sdtContent')
+
+    sdtPr = ZeroOrOne('w:sdtPr', successors=_tag_seq[1:])
+    stEndPr = ZeroOrOne('w:stEndPr', successors=_tag_seq[2:])
+    sdtContent = ZeroOrOne('w:sdtContent', successors=())
+
+    del _tag_seq
+
+class CT_SdtContentBase(BaseOxmlElement):
+    """
+    ``<w:sdtContent>`` represents content within ``<w:sdt>``
+    """
+    r = ZeroOrMore('w:r')
+
+    @property
+    def runs(self):
+        def get_runs(el):
+            for child in el:
+                if child.tag == qn('w:r'):
+                    return child
+                else:
+                    yield from get_runs(child)
+        yield from get_runs(self)

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -50,7 +50,7 @@ class CT_SdtContentBase(BaseOxmlElement):
     """
     p = ZeroOrMore('w:p')
 
-    def get_runs(self):
+    def iter_runs(self):
         def walk(el):
             for child in el:
                 if child.tag == qn('w:r'):

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -1,6 +1,10 @@
 """
 Custom element classes that represent content control
-elements within the document part.
+elements within the document. Since there are four
+types of `sdt` and `sdtContent` elements and types
+for each part of the document (block, cell, row and run).
+`Base` represents single element and element type covering
+all occurrences of `w:sdt` within the document.
 """
 
 from .xmlchemy import BaseOxmlElement, ZeroOrOne, ZeroOrMore
@@ -8,8 +12,8 @@ from .ns import nsmap
 
 class CT_SdtBase(BaseOxmlElement):
     """
-    ``<w:sdt>`` structured document tag element specifying
-    a content control elements.
+    ``<w:sdt>`` structured document tag element (content control)
+    specifies content control elements on any level of document.
     """
     _tag_seq = ('w:sdtPr', 'w:stEndPr', 'w:sdtContent')
 
@@ -24,6 +28,9 @@ class CT_SdtBase(BaseOxmlElement):
         return self.sdtPr.name
 
 class CT_SdtPr(BaseOxmlElement):
+    """
+    ``<w:sdtPr>`` represents property element of ``<w:sdt>`` (content control).
+    """
     tag = ZeroOrOne('w:tag')
     date = ZeroOrOne('w:date')
 
@@ -32,12 +39,13 @@ class CT_SdtPr(BaseOxmlElement):
         try:
             return self.tag.get('{%s}val' % nsmap['w'])
         except:
-            raise Exception('All content controls should be named (having '
-            'set unique content control tag name).')
+            raise Exception('All content controls must have unique names'
+            '(having set unique content control tag name).')
 
 
 class CT_SdtContentBase(BaseOxmlElement):
     """
-    ``<w:sdtContent>`` represents content within ``<w:sdt>``
+    ``<w:sdtContent>`` represents content within ``<w:sdt>`` (content control).'
+    It contains all paragraphs within the content control.
     """
     p = ZeroOrMore('w:p')

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -4,7 +4,7 @@ elements within the document part.
 """
 
 from .xmlchemy import BaseOxmlElement, ZeroOrOne, ZeroOrMore
-from .ns import qn
+from .ns import nsmap
 
 class CT_SdtBase(BaseOxmlElement):
     """
@@ -19,18 +19,25 @@ class CT_SdtBase(BaseOxmlElement):
 
     del _tag_seq
 
+    @property
+    def name(self):
+        return self.sdtPr.name
+
+class CT_SdtPr(BaseOxmlElement):
+    tag = ZeroOrOne('w:tag')
+    date = ZeroOrOne('w:date')
+
+    @property
+    def name(self):
+        try:
+            return self.tag.get('{%s}val' % nsmap['w'])
+        except:
+            raise Exception('All content controls should be named (having '
+            'set unique content control tag name).')
+
+
 class CT_SdtContentBase(BaseOxmlElement):
     """
     ``<w:sdtContent>`` represents content within ``<w:sdt>``
     """
-    r = ZeroOrMore('w:r')
-
-    @property
-    def runs(self):
-        def get_runs(el):
-            for child in el:
-                if child.tag == qn('w:r'):
-                    return child
-                else:
-                    yield from get_runs(child)
-        yield from get_runs(self)
+    p = ZeroOrMore('w:p')

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -82,7 +82,7 @@ class CT_P(BaseOxmlElement):
     def r_lst_recursive(self):
         """
         Override xmlchemy generated list of runs to include runs from
-        hyperlinks.
+        hyperlinks and content controls.
         """
 
         def get_runs(elem):

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -89,8 +89,6 @@ class CT_P(BaseOxmlElement):
             for child in elem:
                 if child.tag == qn('w:r'):
                     yield child
-                elif child.tag == qn('w:hyperlink') \
-                    or child.tag == qn('w:sdt') \
-                    or child.tag == qn('w:sdtContent'):
+                elif child.tag in (qn('w:hyperlink'), qn('w:sdt'), qn('w:sdtContent')):
                     yield from get_runs(child)
         yield from get_runs(self)

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -80,8 +80,7 @@ class CT_P(BaseOxmlElement):
         pPr = self.get_or_add_pPr()
         pPr.style = style
 
-    @property
-    def r_lst_recursive(self):
+    def iter_r_lst_recursive(self):
         """
         Override xmlchemy generated list of runs to include runs from
         hyperlinks and content controls.

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -10,10 +10,11 @@ from ..xmlchemy import BaseOxmlElement, OxmlElement, ZeroOrMore, ZeroOrOne
 
 class CT_P(BaseOxmlElement):
     """
-    ``<w:p>`` element, containing the properties and text for a paragraph.
+    ``<w:p>`` element, containing the properties, text for a paragraph and content controls.
     """
     pPr = ZeroOrOne('w:pPr')
     r = ZeroOrMore('w:r')
+    sdt = ZeroOrMore('w:sdt')
 
     def _insert_pPr(self, pPr):
         self.insert(0, pPr)
@@ -88,6 +89,8 @@ class CT_P(BaseOxmlElement):
             for child in elem:
                 if child.tag == qn('w:r'):
                     yield child
-                elif child.tag == qn('w:hyperlink'):
+                elif child.tag == qn('w:hyperlink') \
+                    or child.tag == qn('w:sdt') \
+                    or child.tag == qn('w:sdtContent'):
                     yield from get_runs(child)
         yield from get_runs(self)

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -109,6 +109,24 @@ class CT_Text(BaseOxmlElement):
     ``<w:t>`` element, containing a sequence of characters within a run.
     """
 
+class CT_SdtRun(BaseOxmlElement):
+    """
+    ``<w:sdt>`` structured document tag element specifying
+    a content control elements.
+    """
+    _tag_seq = ('w:sdtPr', 'w:stEndPr', 'w:sdtContent')
+
+    sdtPr = ZeroOrOne('w:sdtPr', successors=_tag_seq[1:])
+    stEndPr = ZeroOrOne('w:stEndPr', successors=_tag_seq[2:])
+    sdtContent = ZeroOrOne('w:sdtContent')
+
+    del _tag_seq
+
+class CT_SdtContentRun(BaseOxmlElement):
+    """
+    ``<w:sdtContent>`` represents content within ``<w:sdt>``
+    """
+    r = ZeroOrMore('w:r')
 
 class _RunContentAppender(object):
     """

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -109,25 +109,6 @@ class CT_Text(BaseOxmlElement):
     ``<w:t>`` element, containing a sequence of characters within a run.
     """
 
-class CT_SdtRun(BaseOxmlElement):
-    """
-    ``<w:sdt>`` structured document tag element specifying
-    a content control elements.
-    """
-    _tag_seq = ('w:sdtPr', 'w:stEndPr', 'w:sdtContent')
-
-    sdtPr = ZeroOrOne('w:sdtPr', successors=_tag_seq[1:])
-    stEndPr = ZeroOrOne('w:stEndPr', successors=_tag_seq[2:])
-    sdtContent = ZeroOrOne('w:sdtContent')
-
-    del _tag_seq
-
-class CT_SdtContentRun(BaseOxmlElement):
-    """
-    ``<w:sdtContent>`` represents content within ``<w:sdt>``
-    """
-    r = ZeroOrMore('w:r')
-
 class _RunContentAppender(object):
     """
     Service object that knows how to translate a Python string into run

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -1,10 +1,15 @@
+"""
+|SdtBase| and closely related objects.
+"""
 
 from .shared import ElementProxy
 from .text.paragraph import Paragraph
 
 class SdtBase(ElementProxy):
     """
-    Instance of base structured document tag.
+    ``CT_SdtBase`` wrapper object, which contains references to
+    parent object, content control content |SdtContentBase|
+    and properties objects |SdtPr|.
     """
     def __init__(self, element, parent):
         super(SdtBase, self).__init__(element, parent)
@@ -23,7 +28,8 @@ class SdtBase(ElementProxy):
 
 class SdtPr(ElementProxy):
     """
-    Instance of structured document tag properties.
+    ``CT_SdtPr`` wrapper object which has references to
+    parent object |SdtBase|.
     """
     def __init__(self, element, parent):
         super(SdtPr, self).__init__(element, parent)
@@ -33,6 +39,10 @@ class SdtPr(ElementProxy):
         return self._element.name
 
 class SdtContentBase(ElementProxy):
+    """
+    ``CT_SdtContentBase`` wrapper object, which contains references
+    to all paragraphs within the content control, and text property.
+    """
     def __init__(self, element, parent):
         super(SdtContentBase, self).__init__(element, parent)
 

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -53,6 +53,6 @@ class SdtContentBase(ElementProxy):
     @property
     def text(self):
         text = ''
-        for r in self._element.get_runs():
+        for r in self._element.iter_runs():
             text += r.text
         return text

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -53,6 +53,6 @@ class SdtContentBase(ElementProxy):
     @property
     def text(self):
         text = ''
-        for p in self.paragraphs:
-            text += p.text
+        for r in self._element.get_runs():
+            text += r.text
         return text

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -1,9 +1,10 @@
 
 from .shared import ElementProxy
+from .text.paragraph import Paragraph
 
 class SdtBase(ElementProxy):
     """
-    Instance of base structured document tag (block content control).
+    Instance of base structured document tag.
     """
     def __init__(self, element, parent):
         super(SdtBase, self).__init__(element, parent)
@@ -12,14 +13,36 @@ class SdtBase(ElementProxy):
     def content(self):
         return SdtContentBase(self._element.sdtContent, self)
 
+    @property
+    def properties(self):
+        return SdtPr(self._element.sdtPr, self)
+
+    @property
+    def name(self):
+        return self.properties.name
+
+class SdtPr(ElementProxy):
+    """
+    Instance of structured document tag properties.
+    """
+    def __init__(self, element, parent):
+        super(SdtPr, self).__init__(element, parent)
+
+    @property
+    def name(self):
+        return self._element.name
 
 class SdtContentBase(ElementProxy):
     def __init__(self, element, parent):
-        super(SdtContentBase).__init__(element, parent)
+        super(SdtContentBase, self).__init__(element, parent)
+
+    @property
+    def paragraphs(self):
+        return [Paragraph(p, self) for p in self._element.p_lst]
 
     @property
     def text(self):
         text = ''
-        for run in self._element.runs:
-            text += run.text
+        for p in self.paragraphs:
+            text += p.text
         return text

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -1,0 +1,25 @@
+
+from .shared import ElementProxy
+
+class SdtBase(ElementProxy):
+    """
+    Instance of base structured document tag (block content control).
+    """
+    def __init__(self, element, parent):
+        super(SdtBase, self).__init__(element, parent)
+
+    @property
+    def content(self):
+        return SdtContentBase(self._element.sdtContent, self)
+
+
+class SdtContentBase(ElementProxy):
+    def __init__(self, element, parent):
+        super(SdtContentBase).__init__(element, parent)
+
+    @property
+    def text(self):
+        text = ''
+        for run in self._element.runs:
+            text += run.text
+        return text

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -195,7 +195,7 @@ class Paragraph(Parented):
         Sequence of |Run| instances corresponding to the <w:r> elements in
         this paragraph.
         """
-        return [Run(r, self) for r in self._p.r_lst_recursive]
+        return [Run(r, self) for r in self._p.iter_r_lst_recursive()]
 
     @property
     def bookmark_starts(self):


### PR DESCRIPTION
Accessing and reading the content controls.

Unit tests covering these features are available here https://github.com/openlawlibrary/platform/pull/490.

Related to https://github.com/openlawlibrary/platform/issues/491.
See https://github.com/openlawlibrary/platform/issues/490.