### PR TITLE
OLL specific: Display parsed number in paragraph representation.

### DIFF
--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -151,5 +151,7 @@ class Paragraph(Parented):
             text += '...'
         if not text:
             text = "EMPTY PARAGRAPH"
-        text = '<p:"{}">'.format(text)
+        text = '<p:"{}{}">'.format(
+            "{} ".format(str(self.num))
+            if hasattr(self, 'num') and self.num else '', text)
         return text


### PR DESCRIPTION
A small change to support displaying of parsed numbers in paragraphs representations (useful in debugging).

This is OLL specific as `num` is used by OLL parser.