### PR TITLE
autonumbering feature

### DIFF
--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -75,9 +75,12 @@ register_element_cls('w:body',     CT_Body)
 register_element_cls('w:document', CT_Document)
 
 from .numbering import (
-    CT_Num, CT_Numbering, CT_NumLvl, CT_NumPr
+    CT_Num, CT_Numbering, CT_NumLvl, CT_NumPr,
+    CT_AbstractNum, CT_Lvl
 )
+register_element_cls('w:abstractNum',   CT_AbstractNum)
 register_element_cls('w:abstractNumId', CT_DecimalNumber)
+register_element_cls('w:lvl',           CT_Lvl)
 register_element_cls('w:ilvl',          CT_DecimalNumber)
 register_element_cls('w:lvlOverride',   CT_NumLvl)
 register_element_cls('w:num',           CT_Num)

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -74,10 +74,6 @@ class CT_NumPr(BaseOxmlElement):
     ))
     numId = ZeroOrOne('w:numId', successors=('w:numberingChange', 'w:ins'))
 
-    @property
-    def values(self):
-        return self.ilvl.val, self.numId.val
-
     # @ilvl.setter
     # def _set_ilvl(self, val):
     #     """

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -138,6 +138,8 @@ class CT_Numbering(BaseOxmlElement):
         Returns list item for the given paragraph.
         """
         ilvl, numId = p.pPr.get_numPr_tuple(styles_el)
+        if None in (ilvl, numId):
+            return
         abstractNum_el = self.get_abstractNum(numId)
         lvl_el = abstractNum_el.get_lvl(ilvl)
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
@@ -150,7 +152,7 @@ class CT_Numbering(BaseOxmlElement):
                 continue
         p_num = self.fmt_map[lvl_el.numFmt.get('{%s}val' % nsmap['w'])](p_num)
         lvlText = lvl_el.lvlText.get('{%s}val' % nsmap['w'])
-        return re.sub(r'%(\d)', str(p_num), lvlText, 1)
+        return re.sub(r'%(\d)', str(p_num), lvlText, 1) + lvl_el.suffix
 
     def num_having_numId(self, numId):
         """
@@ -201,3 +203,12 @@ class CT_Lvl(BaseOxmlElement):
     start = ZeroOrOne('w:start', CT_DecimalNumber)
     numFmt = ZeroOrOne('w:numFmt')
     lvlText = ZeroOrOne('w:lvlText')
+    suff = ZeroOrOne('w:suff')
+
+    @property
+    def suffix(self):
+        if self.suff is not None:
+            if self.suff.get('{%s}val' % nsmap['w']) == 'space':
+                return ' '
+        else:
+            return '\t'

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -94,6 +94,7 @@ class CT_Numbering(BaseOxmlElement):
     ``<w:numbering>`` element, the root element of a numbering part, i.e.
     numbering.xml
     """
+    abstractNum = ZeroOrMore('w:abstractNum', successors=('w:num', 'w:numIdMacAtCleanup'))
     num = ZeroOrMore('w:num', successors=('w:numIdMacAtCleanup',))
 
     def add_num(self, abstractNum_id):
@@ -104,6 +105,15 @@ class CT_Numbering(BaseOxmlElement):
         next_num_id = self._next_numId
         num = CT_Num.new(next_num_id, abstractNum_id)
         return self._insert_num(num)
+
+    def get_abstractNum(self, abstractNum_id):
+        """
+        Returns |CT_AbstractNum| instance with corresponding
+        ``abstractNum_id`` if any
+        """
+        for el in self.abstractNum_lst:
+            if el.abstractNumId == abstractNum_id:
+                return el
 
     def num_having_numId(self, numId):
         """
@@ -129,3 +139,28 @@ class CT_Numbering(BaseOxmlElement):
             if num not in num_ids:
                 break
         return num
+
+class CT_AbstractNum(BaseOxmlElement):
+    """
+    ``<w:abstractNum>`` element, contains definitions for numbering part.
+    """
+    abstractNumId = RequiredAttribute('w:abstractNumId', ST_DecimalNumber)
+    lvl = ZeroOrMore('w:lvl')
+
+    def get_lvl(self, ilvl):
+        """
+        Returns |CT_Lvl| instance with corresponding ``ilvl`` if any
+        """
+        for el in self.lvl_lst:
+            if el.ilvl == ilvl:
+                return el
+
+class CT_Lvl(BaseOxmlElement):
+    """
+    ``<w:lvl>`` element located within ``<w:abstractNum>`` describing
+    list item formatting
+    """
+    ilvl = RequiredAttribute('w:ilvl', ST_DecimalNumber)
+    start = ZeroOrOne('w:start', CT_DecimalNumber)
+    numFmt = ZeroOrOne('w:numFmt')
+    lvlText = ZeroOrOne('w:lvlText')

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -52,6 +52,21 @@ class CT_P(BaseOxmlElement):
                 continue
             self.remove(child)
 
+    def number(self, numbering_el, style_el):
+        pPr = self.pPr
+        if pPr is None:
+            return None
+        numPr = pPr.numPr
+        if numPr:
+            ilvl, numId = numPr.ilvl.val, numPr.numId.val
+            num_el = numbering_el.num_having_numId(numId)
+            abstractNum_id = num_el.abstractNumId.val
+            abstractNum_el = numbering_el.get_abstractNum(abstractNum_id)
+            import pdb; pdb.set_trace()
+            pass # TODO: handle simple list
+        else:
+            pass # TODO: handle style formated lists
+
     def set_sectPr(self, sectPr):
         """
         Unconditionally replace or add *sectPr* as a grandchild in the

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -3,7 +3,6 @@
 """
 Custom element classes related to paragraphs (CT_P).
 """
-
 from ..ns import qn
 from ..xmlchemy import BaseOxmlElement, OxmlElement, ZeroOrMore, ZeroOrOne
 
@@ -52,20 +51,10 @@ class CT_P(BaseOxmlElement):
                 continue
             self.remove(child)
 
-    def number(self, numbering_el, style_el):
-        pPr = self.pPr
-        if pPr is None:
+    def number(self, numbering_el, styles_el):
+        if self.pPr is None:
             return None
-        numPr = pPr.numPr
-        if numPr:
-            ilvl, numId = numPr.ilvl.val, numPr.numId.val
-            num_el = numbering_el.num_having_numId(numId)
-            abstractNum_id = num_el.abstractNumId.val
-            abstractNum_el = numbering_el.get_abstractNum(abstractNum_id)
-            import pdb; pdb.set_trace()
-            pass # TODO: handle simple list
-        else:
-            pass # TODO: handle style formated lists
+        return numbering_el.get_num_for_p(self, styles_el)
 
     def set_sectPr(self, sectPr):
         """

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,6 +91,17 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
+    def get_numPr_tuple(self, styles_el):
+        """
+        Returns tuple `(ilvl, numId)`. If there's no ``ilvl``
+        default value is 0.
+        """
+        if self.numPr is None:
+            numPr = styles_el.get_by_id(self.pStyle.val).pPr.numPr
+            return 0, numPr.numId.val
+        else:
+            return self.numPr.ilvl.val, self.numPr.numId.val
+
     @property
     def ind_left(self):
         """

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -97,8 +97,11 @@ class CT_PPr(BaseOxmlElement):
         default value is 0.
         """
         if self.numPr is None:
-            numPr = styles_el.get_by_id(self.pStyle.val).pPr.numPr
-            return 0, numPr.numId.val
+            try:
+                numPr = styles_el.get_by_id(self.pStyle.val).pPr.numPr
+                return 0, numPr.numId.val
+            except:
+                return (None, None)
         else:
             return self.numPr.ilvl.val, self.numPr.numId.val
 

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -78,7 +78,7 @@ class Paragraph(Parented):
 
     @property
     def number(self):
-        return self._p.number(self.part.numbering_part._element, self.style._element)
+        return self._p.number(self.part.numbering_part._element, self.part.styles._element)
 
     @property
     def paragraph_format(self):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -77,6 +77,10 @@ class Paragraph(Parented):
         return paragraph
 
     @property
+    def number(self):
+        return self._p.number(self.part.numbering_part._element, self.style._element)
+
+    @property
     def paragraph_format(self):
         """
         The |ParagraphFormat| object providing access to the formatting

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -130,7 +130,7 @@ class Paragraph(Parented):
         Paragraph-level formatting, such as style, is preserved. All
         run-level formatting, such as bold or italic, is removed.
         """
-        text = ''
+        text = self.number if self.number is not None else ''
         for run in self.runs:
             text += run.text
         return text


### PR DESCRIPTION
Implemented autonumbering feature which allows fetching list items for paragraphs within the numbered list.
Unit tests: https://github.com/openlawlibrary/platform/pull/503

Related to https://github.com/openlawlibrary/platform/issues/470.
Closes https://github.com/openlawlibrary/platform/issues/492.
