### PR TITLE
autonumbering fix

### DIFF
--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -183,7 +183,14 @@ class Paragraph(Parented):
 
     @property
     def number(self):
-        return self._p.number(self.part.numbering_part._element, self.part.styles._element)
+        """
+        Gets the list item number with trailing space, if paragraph is part of the numbered
+        list, otherwise returns None.
+        """
+        try:
+            return self._p.number(self.part.numbering_part._element, self.part.styles._element)
+        except:
+            return None
 
     @property
     def paragraph_format(self):


### PR DESCRIPTION
Since `partners\oll\partners\us\ca\cities\san_mateo\tests\docs` failed,
`(v2018.11.0+2527)`-[log.txt](https://github.com/python-openxml/python-docx/files/2672269/log.1.txt)
 and  
`(v2018.11.0+2528)` - [log.txt](https://github.com/python-openxml/python-docx/files/2672268/log.txt)
added `try-except` block for handling exceptions while accessing `para.number`.

Related to https://github.com/openlawlibrary/python-docx/pull/3.

