### PR TITLE
Fixes for `fix autonumbering` branch

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -223,5 +223,7 @@ class CT_Lvl(BaseOxmlElement):
         if self.suff is not None:
             if self.suff.get('{%s}val' % nsmap['w']) == 'space':
                 return ' '
+            else:
+                return ''
         else:
             return '\t'

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -129,20 +129,23 @@ class CT_Numbering(BaseOxmlElement):
             if el.abstractNumId == abstractNum_id:
                 return el
 
-    def get_num_for_p(self, p, styles_el):
+    def get_num_for_p(self, p, styles_cache):
         """
         Returns list item for the given paragraph.
         """
-        ilvl, numId = p.pPr.get_numPr_tuple(styles_el)
-        if None in (ilvl, numId):
-            return
+        numPr = p.pPr.get_numPr(p.pPr.pStyle.val, styles_cache)
+        ilvl, numId = numPr.ilvl, numPr.numId.val
+        ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
         lvl_el = abstractNum_el.get_lvl(ilvl)
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
+
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_ilvl, pp_numId = pp.pPr.get_numPr_tuple(styles_el)
-                if ilvl > pp_ilvl:
+                pp_numPr = pp.pPr.get_numPr(pp.pPr.pStyle.val, styles_cache)
+                pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
+                pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
+                if ilvl > pp_ilvl or (pp_numId != numId and ilvl == pp_ilvl):
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -142,6 +142,8 @@ class CT_Numbering(BaseOxmlElement):
         for pp in p.itersiblings(preceding=True):
             try:
                 pp_ilvl, pp_numId = pp.pPr.get_numPr_tuple(styles_el)
+                if ilvl > pp_ilvl:
+                    break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1
             except:

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -122,7 +122,11 @@ class CT_Numbering(BaseOxmlElement):
         Returns |CT_AbstractNum| instance with corresponding
         paragraph ``pPr.numPr.numId`` if any
         """
-        num_el = self.num_having_numId(numId)
+        try:
+            num_el = self.num_having_numId(numId)
+        except KeyError:
+            return None
+
         abstractNum_id = num_el.abstractNumId.val
 
         for el in self.abstractNum_lst:
@@ -137,6 +141,8 @@ class CT_Numbering(BaseOxmlElement):
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
+        if abstractNum_el is None:
+            return None
         lvl_el = abstractNum_el.get_lvl(ilvl)
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
 
@@ -149,9 +155,13 @@ class CT_Numbering(BaseOxmlElement):
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1
-            except:
+            except (KeyError, AttributeError):
                 continue
-        p_num = self.fmt_map[lvl_el.numFmt.get('{%s}val' % nsmap['w'])](p_num)
+        try:
+            p_num = self.fmt_map[lvl_el.numFmt.get('{%s}val' % nsmap['w'])](p_num)
+        except KeyError:
+            return None
+
         lvlText = lvl_el.lvlText.get('{%s}val' % nsmap['w'])
         return re.sub(r'%(\d)', str(p_num), lvlText, 1) + lvl_el.suffix
 
@@ -180,6 +190,7 @@ class CT_Numbering(BaseOxmlElement):
                 break
         return num
 
+
 class CT_AbstractNum(BaseOxmlElement):
     """
     ``<w:abstractNum>`` element, contains definitions for numbering part.
@@ -194,6 +205,7 @@ class CT_AbstractNum(BaseOxmlElement):
         for el in self.lvl_lst:
             if el.ilvl == ilvl:
                 return el
+
 
 class CT_Lvl(BaseOxmlElement):
     """

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -54,10 +54,8 @@ class CT_P(BaseOxmlElement):
                 continue
             self.remove(child)
 
-    def number(self, numbering_el, styles_el):
-        if self.pPr is None:
-            return None
-        return numbering_el.get_num_for_p(self, styles_el)
+    def number(self, numbering_el, styles_cache):
+        return numbering_el.get_num_for_p(self, styles_cache)
 
     def set_sectPr(self, sectPr):
         """

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,19 +91,15 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr_tuple(self, styles_el):
+    def get_numPr(self, style_id, styles_cache):
         """
-        Returns tuple `(ilvl, numId)`. If there's no ``ilvl``
-        default value is 0.
+        Returns ``numPr`` for paragraph if any, otherwise returns related
+        paragraph style ``numPr``.
         """
-        if self.numPr is None:
-            try:
-                numPr = styles_el.get_by_id(self.pStyle.val).pPr.numPr
-                return 0, numPr.numId.val
-            except:
-                return (None, None)
+        if self.numPr is not None:
+            return self.numPr
         else:
-            return self.numPr.ilvl.val, self.numPr.numId.val
+            return styles_cache[style_id].pPr.numPr
 
     @property
     def ind_left(self):

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -94,12 +94,15 @@ class CT_PPr(BaseOxmlElement):
     def get_numPr(self, style_id, styles_cache):
         """
         Returns ``numPr`` for paragraph if any, otherwise returns related
-        paragraph style ``numPr``.
+        paragraph style ``numPr`` if exists or ``None`` otherwise.
         """
         if self.numPr is not None:
             return self.numPr
         else:
-            return styles_cache[style_id].pPr.numPr
+            try:
+                return styles_cache[style_id].pPr.numPr
+            except KeyError:
+                return None
 
     @property
     def ind_left(self):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -199,7 +199,7 @@ class Paragraph(Parented):
                 self._number = self._p.number(self.part.numbering_part._element,
                                               __class__._p_style_cache)
                 return self._number
-            except:
+            except (AttributeError, NotImplementedError):
                 return None
         else:
             return self._number

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -204,6 +204,10 @@ class Paragraph(Parented):
         else:
             return self._number
 
+    @number.setter
+    def number(self, new_number):
+        self._number = new_number
+
     @property
     def paragraph_format(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -194,10 +194,10 @@ class Paragraph(Parented):
         if self._number is None:
             try:
                 if not __class__._p_style_cache:
-                    styles_dict = {s.style_id:s._element for s in self.part.styles}
+                    styles_dict = {s.style_id: s._element for s in self.part.styles}
                     __class__._p_style_cache.update(styles_dict)
                 self._number = self._p.number(self.part.numbering_part._element,
-                                             __class__._p_style_cache)
+                                              __class__._p_style_cache)
                 return self._number
             except:
                 return None


### PR DESCRIPTION
This PR is an extension of #6 
It provides:
- adding setter for a paragraph `number` property (needed for the DC parser)
- PEP-8 fixes
- Better handling of exception (eliminating bare `except`s). This is important for avoiding some subtle errors down the road.

