### PR TITLE
update autonumbering

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -6,6 +6,7 @@ Custom element classes related to the numbering part
 import re
 from roman import toRoman
 
+from .text.parfmt import CT_PPr
 from . import OxmlElement
 from .shared import CT_DecimalNumber
 from .simpletypes import ST_DecimalNumber
@@ -133,6 +134,16 @@ class CT_Numbering(BaseOxmlElement):
             if el.abstractNumId == abstractNum_id:
                 return el
 
+    def get_lvl_for_p(self, p, styles_cache):
+        """
+        Gets the formatting based on current paragraph indentation level.
+        """
+        numPr = p.pPr.get_numPr(p.pPr.pStyle.val, styles_cache)
+        ilvl, numId = numPr.ilvl, numPr.numId.val
+        ilvl = ilvl.val if ilvl is not None else 0
+        abstractNum_el = self.get_abstractNum(numId)
+        return abstractNum_el.get_lvl(ilvl)
+
     def get_num_for_p(self, p, styles_cache):
         """
         Returns list item for the given paragraph.
@@ -216,6 +227,7 @@ class CT_Lvl(BaseOxmlElement):
     """
     ilvl = RequiredAttribute('w:ilvl', ST_DecimalNumber)
     start = ZeroOrOne('w:start', CT_DecimalNumber)
+    pPr = ZeroOrOne('w:pPr', CT_PPr)
     numFmt = ZeroOrOne('w:numFmt')
     lvlText = ZeroOrOne('w:lvlText')
     suff = ZeroOrOne('w:suff')

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -223,5 +223,7 @@ class CT_Lvl(BaseOxmlElement):
         if self.suff is not None:
             if self.suff.get('{%s}val' % nsmap['w']) == 'space':
                 return ' '
+            else:
+                return ''
         else:
             return '\t'

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -129,20 +129,23 @@ class CT_Numbering(BaseOxmlElement):
             if el.abstractNumId == abstractNum_id:
                 return el
 
-    def get_num_for_p(self, p, styles_el):
+    def get_num_for_p(self, p, styles_cache):
         """
         Returns list item for the given paragraph.
         """
-        ilvl, numId = p.pPr.get_numPr_tuple(styles_el)
-        if None in (ilvl, numId):
-            return
+        numPr = p.pPr.get_numPr(p.pPr.pStyle.val, styles_cache)
+        ilvl, numId = numPr.ilvl, numPr.numId.val
+        ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
         lvl_el = abstractNum_el.get_lvl(ilvl)
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
+
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_ilvl, pp_numId = pp.pPr.get_numPr_tuple(styles_el)
-                if ilvl > pp_ilvl:
+                pp_numPr = pp.pPr.get_numPr(pp.pPr.pStyle.val, styles_cache)
+                pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
+                pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
+                if ilvl > pp_ilvl or (pp_numId != numId and ilvl == pp_ilvl):
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -151,7 +151,9 @@ class CT_Numbering(BaseOxmlElement):
                 pp_numPr = pp.pPr.get_numPr(pp.pPr.pStyle.val, styles_cache)
                 pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
                 pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
-                if ilvl > pp_ilvl or (pp_numId != numId and ilvl == pp_ilvl):
+                if pp_numId == 0:
+                    continue
+                if ilvl > pp_ilvl:
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -142,6 +142,8 @@ class CT_Numbering(BaseOxmlElement):
         for pp in p.itersiblings(preceding=True):
             try:
                 pp_ilvl, pp_numId = pp.pPr.get_numPr_tuple(styles_el)
+                if ilvl > pp_ilvl:
+                    break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1
             except:

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -122,7 +122,11 @@ class CT_Numbering(BaseOxmlElement):
         Returns |CT_AbstractNum| instance with corresponding
         paragraph ``pPr.numPr.numId`` if any
         """
-        num_el = self.num_having_numId(numId)
+        try:
+            num_el = self.num_having_numId(numId)
+        except KeyError:
+            return None
+
         abstractNum_id = num_el.abstractNumId.val
 
         for el in self.abstractNum_lst:
@@ -137,6 +141,8 @@ class CT_Numbering(BaseOxmlElement):
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
+        if abstractNum_el is None:
+            return None
         lvl_el = abstractNum_el.get_lvl(ilvl)
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
 
@@ -149,9 +155,13 @@ class CT_Numbering(BaseOxmlElement):
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1
-            except:
+            except (KeyError, AttributeError):
                 continue
-        p_num = self.fmt_map[lvl_el.numFmt.get('{%s}val' % nsmap['w'])](p_num)
+        try:
+            p_num = self.fmt_map[lvl_el.numFmt.get('{%s}val' % nsmap['w'])](p_num)
+        except KeyError:
+            return None
+
         lvlText = lvl_el.lvlText.get('{%s}val' % nsmap['w'])
         return re.sub(r'%(\d)', str(p_num), lvlText, 1) + lvl_el.suffix
 
@@ -180,6 +190,7 @@ class CT_Numbering(BaseOxmlElement):
                 break
         return num
 
+
 class CT_AbstractNum(BaseOxmlElement):
     """
     ``<w:abstractNum>`` element, contains definitions for numbering part.
@@ -194,6 +205,7 @@ class CT_AbstractNum(BaseOxmlElement):
         for el in self.lvl_lst:
             if el.ilvl == ilvl:
                 return el
+
 
 class CT_Lvl(BaseOxmlElement):
     """

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -51,10 +51,8 @@ class CT_P(BaseOxmlElement):
                 continue
             self.remove(child)
 
-    def number(self, numbering_el, styles_el):
-        if self.pPr is None:
-            return None
-        return numbering_el.get_num_for_p(self, styles_el)
+    def number(self, numbering_el, styles_cache):
+        return numbering_el.get_num_for_p(self, styles_cache)
 
     def set_sectPr(self, sectPr):
         """

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -51,7 +51,16 @@ class CT_P(BaseOxmlElement):
                 continue
             self.remove(child)
 
+    def lvl(self, numbering_el, styles_cache):
+        """
+        Returns ``<w:lvl>`` element formatting for the current paragraph.
+        """
+        return numbering_el.get_lvl_for_p(self, styles_cache)
+
     def number(self, numbering_el, styles_cache):
+        """
+        Returns numbering part of the paragraph if any, else returns None.
+        """
         return numbering_el.get_num_for_p(self, styles_cache)
 
     def set_sectPr(self, sectPr):

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,19 +91,15 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr_tuple(self, styles_el):
+    def get_numPr(self, style_id, styles_cache):
         """
-        Returns tuple `(ilvl, numId)`. If there's no ``ilvl``
-        default value is 0.
+        Returns ``numPr`` for paragraph if any, otherwise returns related
+        paragraph style ``numPr``.
         """
-        if self.numPr is None:
-            try:
-                numPr = styles_el.get_by_id(self.pStyle.val).pPr.numPr
-                return 0, numPr.numId.val
-            except:
-                return (None, None)
+        if self.numPr is not None:
+            return self.numPr
         else:
-            return self.numPr.ilvl.val, self.numPr.numId.val
+            return styles_cache[style_id].pPr.numPr
 
     @property
     def ind_left(self):

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -94,12 +94,15 @@ class CT_PPr(BaseOxmlElement):
     def get_numPr(self, style_id, styles_cache):
         """
         Returns ``numPr`` for paragraph if any, otherwise returns related
-        paragraph style ``numPr``.
+        paragraph style ``numPr`` if exists or ``None`` otherwise.
         """
         if self.numPr is not None:
             return self.numPr
         else:
-            return styles_cache[style_id].pPr.numPr
+            try:
+                return styles_cache[style_id].pPr.numPr
+            except KeyError:
+                return None
 
     @property
     def ind_left(self):

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -28,6 +28,18 @@ class DocumentPart(XmlPart):
     inherited by many content objects provides access to this part object for
     that purpose.
     """
+
+    @property
+    def cached_styles(self):
+        """
+        Caching collection of styles on document loading, since method `styles`
+        is generating new styles per call, and can be time consuming
+        """
+        if not hasattr(self, '_cached_styles'):
+            cached_styles = {s.style_id: s._element for s in self.styles}
+            setattr(self, '_cached_styles', cached_styles)
+        return self._cached_styles
+
     @property
     def core_properties(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -23,6 +23,7 @@ class Paragraph(Parented):
         super(Paragraph, self).__init__(parent)
         self._p = self._element = p
         self._number = None
+        self._lvl = None
 
     def add_run(self, text=None, style=None):
         """
@@ -97,6 +98,28 @@ class Paragraph(Parented):
     @number.setter
     def number(self, new_number):
         self._number = new_number
+
+    @property
+    def lvl(self):
+        """
+        Gets the `lvl` element based on the indentation index.
+        """
+        if self._lvl is None:
+            try:
+                self._lvl = self._p.lvl(self.part.numbering_part._element, self.part.cached_styles)
+                return self._lvl
+            except:
+                return None
+        else:
+            return self._lvl
+
+    @property
+    def numbering_format(self):
+        """
+        Returns |ParagraphFormat| object based on the formatting for the given
+        level of the numbered list.
+        """
+        return ParagraphFormat(self.lvl) if self.lvl is not None else None
 
     @property
     def paragraph_format(self):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -19,8 +19,6 @@ class Paragraph(Parented):
     Proxy object wrapping ``<w:p>`` element.
     """
 
-    _p_style_cache = {}
-
     def __init__(self, p, parent):
         super(Paragraph, self).__init__(parent)
         self._p = self._element = p
@@ -88,11 +86,8 @@ class Paragraph(Parented):
         """
         if self._number is None:
             try:
-                if not __class__._p_style_cache:
-                    styles_dict = {s.style_id: s._element for s in self.part.styles}
-                    __class__._p_style_cache.update(styles_dict)
                 self._number = self._p.number(self.part.numbering_part._element,
-                                              __class__._p_style_cache)
+                                              self.part.cached_styles)
                 return self._number
             except (AttributeError, NotImplementedError):
                 return None

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -89,10 +89,10 @@ class Paragraph(Parented):
         if self._number is None:
             try:
                 if not __class__._p_style_cache:
-                    styles_dict = {s.style_id:s._element for s in self.part.styles}
+                    styles_dict = {s.style_id: s._element for s in self.part.styles}
                     __class__._p_style_cache.update(styles_dict)
                 self._number = self._p.number(self.part.numbering_part._element,
-                                             __class__._p_style_cache)
+                                              __class__._p_style_cache)
                 return self._number
             except:
                 return None

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -99,6 +99,10 @@ class Paragraph(Parented):
         else:
             return self._number
 
+    @number.setter
+    def number(self, new_number):
+        self._number = new_number
+
     @property
     def paragraph_format(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -94,7 +94,7 @@ class Paragraph(Parented):
                 self._number = self._p.number(self.part.numbering_part._element,
                                               __class__._p_style_cache)
                 return self._number
-            except:
+            except (AttributeError, NotImplementedError):
                 return None
         else:
             return self._number

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -108,7 +108,7 @@ class Paragraph(Parented):
             try:
                 self._lvl = self._p.lvl(self.part.numbering_part._element, self.part.cached_styles)
                 return self._lvl
-            except:
+            except AttributeError:
                 return None
         else:
             return self._lvl

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -78,7 +78,14 @@ class Paragraph(Parented):
 
     @property
     def number(self):
-        return self._p.number(self.part.numbering_part._element, self.part.styles._element)
+        """
+        Gets the list item number with trailing space, if paragraph is part of the numbered
+        list, otherwise returns None.
+        """
+        try:
+            return self._p.number(self.part.numbering_part._element, self.part.styles._element)
+        except:
+            return None
 
     @property
     def paragraph_format(self):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -18,9 +18,13 @@ class Paragraph(Parented):
     """
     Proxy object wrapping ``<w:p>`` element.
     """
+
+    _p_style_cache = {}
+
     def __init__(self, p, parent):
         super(Paragraph, self).__init__(parent)
         self._p = self._element = p
+        self._number = None
 
     def add_run(self, text=None, style=None):
         """
@@ -82,10 +86,18 @@ class Paragraph(Parented):
         Gets the list item number with trailing space, if paragraph is part of the numbered
         list, otherwise returns None.
         """
-        try:
-            return self._p.number(self.part.numbering_part._element, self.part.styles._element)
-        except:
-            return None
+        if self._number is None:
+            try:
+                if not __class__._p_style_cache:
+                    styles_dict = {s.style_id:s._element for s in self.part.styles}
+                    __class__._p_style_cache.update(styles_dict)
+                self._number = self._p.number(self.part.numbering_part._element,
+                                             __class__._p_style_cache)
+                return self._number
+            except:
+                return None
+        else:
+            return self._number
 
     @property
     def paragraph_format(self):
@@ -137,7 +149,8 @@ class Paragraph(Parented):
         Paragraph-level formatting, such as style, is preserved. All
         run-level formatting, such as bold or italic, is removed.
         """
-        text = self.number if self.number is not None else ''
+        para_num = self.number
+        text = para_num if para_num is not None else ''
         for run in self.runs:
             text += run.text
         return text


### PR DESCRIPTION
PR containing bug resolves and enhancements.
Replacement of the PR https://github.com/openlawlibrary/python-docx/pull/6 since, because that PR was based off `merge-all` branch instead of `aleksandarbos/autonumbering`.

Details:
fixed numbering calculation. before it searched for all list items with
same indentation level and style, but didn't take care about list items
in between. Now if it founds list item that is less indented than
current list item, then it should stop iterating any further.

Related to #3, openlawlibrary/platform#492.