### PR TITLE
merge image content type fix

### DIFF
--- a/docx/image/image.py
+++ b/docx/image/image.py
@@ -177,7 +177,7 @@ class Image(object):
         image_header = _ImageHeaderFactory(stream)
         if filename is None:
             filename = 'image.%s' % image_header.default_ext
-        return cls(blob, filename, image_header)
+        return cls(blob, filename, image_header, 'image/%s' % image_header.default_ext)
 
 
 def _ImageHeaderFactory(stream):


### PR DESCRIPTION
- while creating image (calling Image contructor) content type was not
specified, and default content type was used instead. image content
type from image_header is passed to the Image contructor, which
should set correct content type instead of `uknown`.