### PR TITLE
update version to 0.8.8

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.7'
+__version__ = '0.8.8'
 
 
 # register custom Part classes with opc package reader


### PR DESCRIPTION
Updating version to the `0.8.8` due the installation error (pip doesn't fetch latest python-docx with the highest build number).