### PR TITLE
ordinary autonumbering merge into merge-all

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml>=3.1.0
 mock>=1.0.1
 pyparsing>=2.0.1
 pytest>=2.5
+roman>=3.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ LICENSE = text_of('LICENSE')
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 PACKAGE_DATA = {'docx': ['templates/*']}
 
-INSTALL_REQUIRES = ['lxml>=2.3.2']
+INSTALL_REQUIRES = ['lxml>=2.3.2', 'roman>=3.0']
 TEST_SUITE = 'tests'
 TESTS_REQUIRE = ['behave', 'mock', 'pyparsing', 'pytest']
 


### PR DESCRIPTION
Merging ordinary autonumbering feature https://github.com/openlawlibrary/platform/issues/778 into `merge-all`.