### PR TITLE
Remove `__slots__` from `Document` class

### DIFF
--- a/docx/document.py
+++ b/docx/document.py
@@ -22,7 +22,7 @@ class Document(ElementProxy):
     Use :func:`docx.Document` to open or create a document.
     """
 
-    __slots__ = ('_part', '__body', '_bookmarks')
+    # __slots__ = ('_part', '__body', '_bookmarks')
 
     def __init__(self, element, part):
         super(Document, self).__init__(element)


### PR DESCRIPTION
We are adding attributes dynamically so we can't use slots