### PR TITLE
added support for upperRoman numbering style

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -109,6 +109,7 @@ class CT_Numbering(BaseOxmlElement):
         'upperLetter': lambda num: (chr(64 + (num % 26 if num % 26 != 0 else 26))
                                     * math.ceil(num / 26)),
         'lowerRoman': lambda num: toRoman(num).lower(),
+        'upperRoman': lambda num: toRoman(num),
         'none': lambda num: '',
     }
 


### PR DESCRIPTION
added support for `upperRoman` numbering style, 5th lvl indent style for the SMC.

- [ ] once this is merged, it's necessary to create another PR from `feature/autonumbering` against `merge-all`

Tests: https://github.com/openlawlibrary/platform/pull/1230.

Related to https://github.com/openlawlibrary/platform/issues/1226.