### PR TITLE
update autonumbering

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.8'
+__version__ = '0.8.8.1'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -109,6 +109,7 @@ class CT_Numbering(BaseOxmlElement):
         'upperLetter': lambda num: (chr(64 + (num % 26 if num % 26 != 0 else 26))
                                     * math.ceil(num / 26)),
         'lowerRoman': lambda num: toRoman(num).lower(),
+        'upperRoman': lambda num: toRoman(num),
         'none': lambda num: '',
     }
 


### PR DESCRIPTION
- updating `merge-all` with latest changes on `feature/autonumbering` branch.
- updating version to `0.8.8.1`, in order to increase version number and to preserve original numbering minor version.

Related to https://github.com/openlawlibrary/python-docx/pull/32.