### PR TITLE
performance enhancements

### DIFF
--- a/docx/oxml/xmlchemy.py
+++ b/docx/oxml/xmlchemy.py
@@ -26,6 +26,7 @@ def serialize_for_reading(element):
     xml = etree.tostring(element, encoding='unicode', pretty_print=True)
     return XmlString(xml)
 
+xpath_cache = {}
 
 class XmlString(Unicode):
     """
@@ -742,14 +743,17 @@ class _OxmlElementBase(etree.ElementBase):
         """
         return serialize_for_reading(self)
 
-    def xpath(self, xpath_str):
+    def xpath(self, xpath_str, **kwargs):
         """
         Override of ``lxml`` _Element.xpath() method to provide standard Open
         XML namespace mapping (``nsmap``) in centralized location.
         """
-        return super(BaseOxmlElement, self).xpath(
-            xpath_str, namespaces=nsmap
-        )
+        if xpath_str not in xpath_cache:
+            xpath_cache[xpath_str] = etree.XPath(
+                xpath_str, namespaces=nsmap)
+
+        xpath = xpath_cache[xpath_str]
+        return xpath(self, **kwargs)
 
     @property
     def _nsptag(self):

--- a/docx/shared.py
+++ b/docx/shared.py
@@ -5,6 +5,7 @@ Objects shared by docx modules.
 """
 
 from __future__ import absolute_import, print_function, unicode_literals
+from functools import wraps
 
 
 class Length(int):
@@ -248,3 +249,27 @@ class Parented(object):
         The package part containing this object
         """
         return self._parent.part
+
+
+def cache(fn):
+    @wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        fn_name = fn.__name__
+        key = (tuple(args), tuple((k, v) for k, v in kwargs.items()))
+        try:
+            return self._cache[fn_name][key]
+        except KeyError:
+            out = fn(self, *args, **kwargs)
+            self._cache.setdefault(fn_name, {})[key] = out
+            return out
+    return wrapper
+
+def bust_cache(fn_name):
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            out = fn(self, *args, **kwargs)
+            self._cache[fn_name] = {}
+            return out
+        return wrapper
+    return decorator


### PR DESCRIPTION
* cache xpath queries
* cache style objects
* cache text
  * invalidate text where needed
* add `replace_chars` to replace multiple
  pairs of characters in one pass
* reduce number of lxml calls in norm_left_indent
* TODO: invalidate paragraph text cache when operating on runs!

## Description (e.g. "Related to ...", "Closes ...", etc.)



## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
