### PR TITLE
Performance improvements

### DIFF
--- a/docx/shared.py
+++ b/docx/shared.py
@@ -264,12 +264,14 @@ def cache(fn):
             return out
     return wrapper
 
-def bust_cache(fn_name):
+
+def bust_cache(fn_names):
     def decorator(fn):
         @wraps(fn)
         def wrapper(self, *args, **kwargs):
             out = fn(self, *args, **kwargs)
-            self._cache[fn_name] = {}
+            for fn_name in fn_names:
+                self._cache[fn_name] = {}
             return out
         return wrapper
     return decorator

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -290,7 +290,15 @@ class Paragraph(Parented, BookmarkParent):
         prev_el = prev._element if prev else None
         _ilvl = 0 if ilvl is None else ilvl
         self._p.set_li_lvl(self.part.numbering_part._element,
-                              self.part.cached_styles, prev_el, _ilvl)
+                           self.part.cached_styles, prev_el, _ilvl)
+
+    @property
+    @cache
+    def run_text(self):
+        if self.runs:
+            return ''.join(r.text for r in self.runs)
+        else:
+            return ''
 
     @property
     @cache
@@ -308,10 +316,7 @@ class Paragraph(Parented, BookmarkParent):
         run-level formatting, such as bold or italic, is removed.
         """
         para_num = self.number
-        text = para_num if para_num is not None else ''
-        for run in self.runs:
-            text += run.text
-        return text
+        return (para_num if para_num is not None else '') + self.run_text
 
     @text.setter
     def text(self, text):


### PR DESCRIPTION
- utilize `bust_cache` to make a decorator for clearing text-related cache on all text changing operations
- Added `run_text` on paragraph for accessing only the text without number (used in actions)


## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
