### PR TITLE
fix simple autonumbering

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.8.2'
+__version__ = '0.8.8.3'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -147,7 +147,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_numPr(p.pPr.pStyle.val, styles_cache)
+        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -157,7 +157,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Returns list item for the given paragraph.
         """
-        numPr = p.pPr.get_numPr(p.pPr.pStyle.val, styles_cache)
+        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -168,7 +168,7 @@ class CT_Numbering(BaseOxmlElement):
 
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_numPr = pp.pPr.get_numPr(pp.pPr.pStyle.val, styles_cache)
+                pp_numPr = pp.pPr.get_numPr(pp.pPr, styles_cache)
                 pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
                 pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
                 if pp_numId == 0:

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,17 +91,17 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, style_id, styles_cache):
+    def get_numPr(self, pPr, styles_cache):
         """
         Returns ``numPr`` for paragraph if any, otherwise returns related
         paragraph style ``numPr`` if exists or ``None`` otherwise.
         """
-        if self.numPr is not None:
-            return self.numPr
+        if pPr.numPr is not None:
+            return pPr.numPr
         else:
             try:
-                return styles_cache[style_id].pPr.numPr
-            except KeyError:
+                return styles_cache[pPr.pStyle.val].pPr.numPr
+            except (KeyError, AttributeError):
                 return None
 
     @property


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

merging to `merge-all` latest fixes from `feature/autonumbering` branch. also bumped python-docx version

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
