### PR TITLE
add bookmarks table supp, fixed reading bookmarks on doc level 

### DIFF
--- a/docx/bookmark.py
+++ b/docx/bookmark.py
@@ -177,7 +177,11 @@ class _PartBookmarkFinder(object):
 
         Elements appear in document order.
         """
-        return self._part.element.xpath("//w:bookmarkStart|//w:bookmarkEnd")
+        part_el = getattr(self._part, 'element', None)
+        if part_el is not None:
+            return part_el.xpath("//w:bookmarkStart|//w:bookmarkEnd")
+        else:
+            return []
 
     def _iter_starts(self):
         """Generate (idx, bookmarkStart) elements in story.

--- a/docx/oxml/table.py
+++ b/docx/oxml/table.py
@@ -69,9 +69,11 @@ class CT_Tbl(BaseOxmlElement):
     """
     ``<w:tbl>`` element
     """
+    bookmarkStart = ZeroOrMore('w:bookmarkStart', successors=('w:tblPr', 'w:tblGrid', 'w:tr',))
     tblPr = OneAndOnlyOne('w:tblPr')
     tblGrid = OneAndOnlyOne('w:tblGrid')
     tr = ZeroOrMore('w:tr')
+    bookmarkEnd = ZeroOrMore('w:bookmarkEnd')
 
     @property
     def bidiVisual_val(self):

--- a/docx/table.py
+++ b/docx/table.py
@@ -10,9 +10,10 @@ from .blkcntnr import BlockItemContainer
 from .enum.style import WD_STYLE_TYPE
 from .oxml.simpletypes import ST_Merge
 from .shared import Inches, lazyproperty, Parented
+from docx.bookmark import BookmarkParent
 
 
-class Table(Parented):
+class Table(Parented, BookmarkParent):
     """
     Proxy class for a WordprocessingML ``<w:tbl>`` element.
     """
@@ -71,6 +72,14 @@ class Table(Parented):
     @autofit.setter
     def autofit(self, value):
         self._tblPr.autofit = value
+
+    @property
+    def bookmark_starts(self):
+        return self._element.bookmarkStart_lst
+
+    @property
+    def bookmark_ends(self):
+        return self._element.bookmarkEnd_lst
 
     def cell(self, row_idx, col_idx):
         """


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- since docx document has many parts including header, footer, body,
not all parts have python-docx layer model representation. in case of
header part it will provide xml model which is "element" itself and it
will keep raising AttributeError. Bookmarks are now retreived only for
those parts that have python-docx model representation and therefore
reference to "elemenet" or xml object representation.
- added reading and writing bookmarks feature for docx tables

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
