### PR TITLE
merge-all -> fix simple list indent

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -147,7 +147,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
+        numPr = p.pPr.get_numPr(styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -157,7 +157,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Returns list item for the given paragraph.
         """
-        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
+        numPr = p.pPr.get_numPr(styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -168,7 +168,7 @@ class CT_Numbering(BaseOxmlElement):
 
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_numPr = pp.pPr.get_numPr(pp.pPr, styles_cache)
+                pp_numPr = pp.pPr.get_numPr(styles_cache)
                 pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
                 pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
                 if pp_numId == 0:
@@ -225,7 +225,7 @@ class CT_Numbering(BaseOxmlElement):
                 prev_p.pPr.numPr.numId is None):
             if ilvl is None:
                 ilvl = 0
-            numPr = para_el.pPr.get_numPr(para_el.pPr, styles)
+            numPr = para_el.pPr.get_numPr(styles)
             numId = numPr.numId.val
             num_el = self.num_having_numId(numId)
             anum = num_el.abstractNumId.val

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,16 +91,16 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, pPr, styles_cache):
+    def get_numPr(self, styles_cache):
         """
         Returns ``numPr`` for paragraph if any, otherwise returns related
         paragraph style ``numPr`` if exists or ``None`` otherwise.
         """
-        if pPr.numPr is not None:
-            return pPr.numPr
+        if self.numPr is not None:
+            return self.numPr
         else:
             try:
-                return styles_cache[pPr.pStyle.val].pPr.numPr
+                return styles_cache[self.pStyle.val].pPr.numPr
             except (KeyError, AttributeError):
                 return None
 

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -504,8 +504,10 @@ class Paragraph(Parented, BookmarkParent):
             left_indent = round(left_indent.inches, 2)
 
         if self.numbering_format:
-            indent = (first_line_indent or self.numbering_format.first_line_indent.inches) \
-                + (left_indent or self.numbering_format.left_indent.inches)
+            indent = first_line_indent if first_line_indent is not None \
+                 else self.numbering_format.first_line_indent.inches
+            indent += left_indent if left_indent is not None \
+                else self.numbering_format.left_indent.inches
         else:
             # If para is not numbered we shall calculate using tabs and tab stops
             DEFAULT_TAB_STOP = 0.5


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

merging this https://github.com/openlawlibrary/python-docx/pull/45 work into `merge-all` if approved.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
