### PR TITLE
simplified get_numPr

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -143,7 +143,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
+        numPr = p.pPr.get_numPr(styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -153,7 +153,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Returns list item for the given paragraph.
         """
-        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
+        numPr = p.pPr.get_numPr(styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -164,7 +164,7 @@ class CT_Numbering(BaseOxmlElement):
 
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_numPr = pp.pPr.get_numPr(pp.pPr, styles_cache)
+                pp_numPr = pp.pPr.get_numPr(styles_cache)
                 pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
                 pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
                 if pp_numId == 0:
@@ -221,7 +221,7 @@ class CT_Numbering(BaseOxmlElement):
                 prev_p.pPr.numPr.numId is None):
             if ilvl is None:
                 ilvl = 0
-            numPr = para_el.pPr.get_numPr(para_el.pPr, styles)
+            numPr = para_el.pPr.get_numPr(styles)
             numId = numPr.numId.val
             num_el = self.num_having_numId(numId)
             anum = num_el.abstractNumId.val

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,16 +91,16 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, pPr, styles_cache):
+    def get_numPr(self, styles_cache):
         """
         Returns ``numPr`` for paragraph if any, otherwise returns related
         paragraph style ``numPr`` if exists or ``None`` otherwise.
         """
-        if pPr.numPr is not None:
-            return pPr.numPr
+        if self.numPr is not None:
+            return self.numPr
         else:
             try:
-                return styles_cache[pPr.pStyle.val].pPr.numPr
+                return styles_cache[self.pStyle.val].pPr.numPr
             except (KeyError, AttributeError):
                 return None
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- currently we're calling method on instance level and passing the same
instance as argument. removed overuse


## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
