### PR TITLE
Feature/extend tabstops

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ---------------
 
+0.8.6 (2016-06-22)
+++++++++++++++++++
+
+- Add #257: add Font.highlight_color
+- Add #261: add ParagraphFormat.tab_stops
+- Add #303: disallow XML entity expansion
+
+
 0.8.5 (2015-02-21)
 ++++++++++++++++++
 

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 
 
 # register custom Part classes with opc package reader

--- a/docx/text/tabstops.py
+++ b/docx/text/tabstops.py
@@ -8,6 +8,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
+from ..oxml.ns import qn
 from ..shared import ElementProxy
 from docx.enum.text import WD_TAB_ALIGNMENT, WD_TAB_LEADER
 
@@ -111,6 +112,15 @@ class TabStop(ElementProxy):
     @alignment.setter
     def alignment(self, value):
         self._tab.val = value
+
+    @property
+    def is_clear(self):
+        """
+        Returns `True` if |TabStop| "w:val" is "clear" which means that tabstop
+        is overridden by some substyle / paragraph settings, and it's not actively used.
+        Otherwise returns `False`.
+        """
+        return self._tab.attrib[qn('w:val')] == 'clear'
 
     @property
     def leader(self):


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- note that clear method exists as part of etree implementation, so for
that reason, added is_clear property that will indicate if tabstop is
actively being used or not.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
