### PR TITLE
release 0.8.8.5

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.8.4'
+__version__ = '0.8.8.5'
 
 
 # register custom Part classes with opc package reader


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)
changes:
- releasing new tabstop indicator `is_clear`

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [x] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
