### PR TITLE
autonumbering feature refactoring (improving)

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -9,7 +9,7 @@ from roman import toRoman
 
 from .text.parfmt import CT_PPr
 from . import OxmlElement
-from .shared import CT_DecimalNumber
+from .shared import CT_DecimalNumber, CT_String
 from .simpletypes import ST_DecimalNumber
 from .xmlchemy import (
     BaseOxmlElement, OneAndOnlyOne, RequiredAttribute, ZeroOrMore, ZeroOrOne
@@ -138,37 +138,54 @@ class CT_Numbering(BaseOxmlElement):
             if el.abstractNumId == abstractNum_id:
                 return el
 
+    def get_numId_lvl_for_p(self, p, styles_cache):
+        """
+        Returns tuple of `(numId, lvl)` where `numId` represent identifier which
+        references to numbering instance, and `lvl` object represents relevant level of
+        numbering scheme necessary information about paragraph indentation level and formating.
+        """
+        lvl = None
+        if p.pPr.numPr is not None: # numbering using paragraph formatting
+            numPr = p.pPr.numPr
+            abstractNum_el = self.get_abstractNum(numPr.numId.val)
+            lvl = abstractNum_el.get_lvl(numPr.ilvl.val)
+        else:
+            numPr = styles_cache[p.pPr.pStyle.val].pPr.numPr # numbering using styles
+            if numPr is None:
+                return None, None
+            abstractNum_el = self.get_abstractNum(numPr.numId.val)
+            for lvl_el in abstractNum_el.lvl_lst:
+                if getattr(lvl_el.pStyle, 'val', None) == p.pPr.pStyle.val:
+                    lvl = lvl_el
+                    break
+        numId = numPr.numId.val
+        return numId, lvl
+
     def get_lvl_for_p(self, p, styles_cache):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_numPr(styles_cache)
-        ilvl, numId = numPr.ilvl, numPr.numId.val
-        ilvl = ilvl.val if ilvl is not None else 0
-        abstractNum_el = self.get_abstractNum(numId)
-        return abstractNum_el.get_lvl(ilvl)
+        _, lvl = self.get_numId_lvl_for_p(p, styles_cache)
+        return lvl
 
     def get_num_for_p(self, p, styles_cache):
         """
         Returns list item for the given paragraph.
         """
-        numPr = p.pPr.get_numPr(styles_cache)
-        ilvl, numId = numPr.ilvl, numPr.numId.val
-        ilvl = ilvl.val if ilvl is not None else 0
-        abstractNum_el = self.get_abstractNum(numId)
-        if abstractNum_el is None:
+        numId, lvl_el = self.get_numId_lvl_for_p(p, styles_cache)
+        if not all(map(lambda x: x is not None, (numId, lvl_el))):
             return None
-        lvl_el = abstractNum_el.get_lvl(ilvl)
+        ilvl = lvl_el.ilvl
+        linked_styles = {s.pStyle.val for s in lvl_el.xpath('preceding-sibling::w:lvl[w:pStyle]')}
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
 
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_numPr = pp.pPr.get_numPr(styles_cache)
-                pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
-                pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
-                if pp_numId == 0:
+                pp_numId, pp_lvl_el = self.get_numId_lvl_for_p(pp, styles_cache)
+                pp_ilvl = pp_lvl_el.ilvl
+                if pp_numId == 0:   # numbering removed (not displayed) for particular para
                     continue
-                if ilvl > pp_ilvl:
+                if ilvl > pp_ilvl and (numId == pp_numId or pp.pPr.pStyle.val in linked_styles):
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1
@@ -231,6 +248,7 @@ class CT_Lvl(BaseOxmlElement):
     ilvl = RequiredAttribute('w:ilvl', ST_DecimalNumber)
     start = ZeroOrOne('w:start', CT_DecimalNumber)
     pPr = ZeroOrOne('w:pPr', CT_PPr)
+    pStyle = ZeroOrOne('w:pStyle', CT_String)
     numFmt = ZeroOrOne('w:numFmt')
     lvlText = ZeroOrOne('w:lvlText')
     suff = ZeroOrOne('w:suff')

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -140,9 +140,10 @@ class CT_Numbering(BaseOxmlElement):
 
     def get_numId_lvl_for_p(self, p, styles_cache):
         """
-        Returns tuple of `(numId, lvl)` where `numId` represent identifier which
-        references to numbering instance, and `lvl` object represents relevant level of
-        numbering scheme necessary information about paragraph indentation level and formating.
+        Returns tuple of `(numId, lvl)` where `w:numId` points to
+        related numbering instance defined in numbering part, and
+        `w:lvl` provides information about particular numbering level for
+        given paragraph `p`.
         """
         lvl = None
         if p.pPr.numPr is not None: # numbering using paragraph formatting
@@ -173,7 +174,7 @@ class CT_Numbering(BaseOxmlElement):
         Returns list item for the given paragraph.
         """
         numId, lvl_el = self.get_numId_lvl_for_p(p, styles_cache)
-        if not all(map(lambda x: x is not None, (numId, lvl_el))):
+        if numId is None or lvl_el is None:
             return None
         ilvl = lvl_el.ilvl
         linked_styles = {s.pStyle.val for s in lvl_el.xpath('preceding-sibling::w:lvl[w:pStyle]')}

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,19 +91,6 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, styles_cache):
-        """
-        Returns ``numPr`` for paragraph if any, otherwise returns related
-        paragraph style ``numPr`` if exists or ``None`` otherwise.
-        """
-        if self.numPr is not None:
-            return self.numPr
-        else:
-            try:
-                return styles_cache[self.pStyle.val].pPr.numPr
-            except (KeyError, AttributeError):
-                return None
-
     @property
     def ind_left(self):
         """


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- deleted `get_numPr` method from paragraph formating layer, instead
implemented method for fetching `lvl` and `numId` on numbering
part/layer. logic for determining `numId` and `ivl` is now encapsulated
within `get_numId_lvl_for_p` method. Based on documentation provided in
ooxml specification [1] `numId` is always determined within paragraph's
formating properties `pPr -> numId`. In case where numbering is done
using styles information about `ilvl` is read from `w:lvl` element which
contains `pStyle` reference towards paragraph style.
- extended previous implementation, so numbering gets reset once linked
style item is provided on lower levels of indentation (ilvl) within
numbering definition (abstractNum).
[1]: http://officeopenxml.com/WPparagraphProperties.php,
http://officeopenxml.com/WPnumberingLvl.php


## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
