### PR TITLE
release 0.8.8.6

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.8.5'
+__version__ = '0.8.8.6'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -9,7 +9,7 @@ from roman import toRoman
 
 from .text.parfmt import CT_PPr
 from . import OxmlElement
-from .shared import CT_DecimalNumber
+from .shared import CT_DecimalNumber, CT_String
 from .simpletypes import ST_DecimalNumber
 from .xmlchemy import (
     BaseOxmlElement, OneAndOnlyOne, RequiredAttribute, ZeroOrMore, ZeroOrOne
@@ -143,37 +143,55 @@ class CT_Numbering(BaseOxmlElement):
             if el.abstractNumId == abstractNum_id:
                 return el
 
+    def get_numId_lvl_for_p(self, p, styles_cache):
+        """
+        Returns tuple of `(numId, lvl)` where `w:numId` points to
+        related numbering instance defined in numbering part, and
+        `w:lvl` provides information about particular numbering level for
+        given paragraph `p`.
+        """
+        lvl = None
+        if p.pPr.numPr is not None: # numbering using paragraph formatting
+            numPr = p.pPr.numPr
+            abstractNum_el = self.get_abstractNum(numPr.numId.val)
+            lvl = abstractNum_el.get_lvl(numPr.ilvl.val)
+        else:
+            numPr = styles_cache[p.pPr.pStyle.val].pPr.numPr # numbering using styles
+            if numPr is None:
+                return None, None
+            abstractNum_el = self.get_abstractNum(numPr.numId.val)
+            for lvl_el in abstractNum_el.lvl_lst:
+                if getattr(lvl_el.pStyle, 'val', None) == p.pPr.pStyle.val:
+                    lvl = lvl_el
+                    break
+        numId = numPr.numId.val
+        return numId, lvl
+
     def get_lvl_for_p(self, p, styles_cache):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_numPr(styles_cache)
-        ilvl, numId = numPr.ilvl, numPr.numId.val
-        ilvl = ilvl.val if ilvl is not None else 0
-        abstractNum_el = self.get_abstractNum(numId)
-        return abstractNum_el.get_lvl(ilvl)
+        _, lvl = self.get_numId_lvl_for_p(p, styles_cache)
+        return lvl
 
     def get_num_for_p(self, p, styles_cache):
         """
         Returns list item for the given paragraph.
         """
-        numPr = p.pPr.get_numPr(styles_cache)
-        ilvl, numId = numPr.ilvl, numPr.numId.val
-        ilvl = ilvl.val if ilvl is not None else 0
-        abstractNum_el = self.get_abstractNum(numId)
-        if abstractNum_el is None:
+        numId, lvl_el = self.get_numId_lvl_for_p(p, styles_cache)
+        if numId is None or lvl_el is None:
             return None
-        lvl_el = abstractNum_el.get_lvl(ilvl)
+        ilvl = lvl_el.ilvl
+        linked_styles = {s.pStyle.val for s in lvl_el.xpath('preceding-sibling::w:lvl[w:pStyle]')}
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
 
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_numPr = pp.pPr.get_numPr(styles_cache)
-                pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
-                pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
-                if pp_numId == 0:
+                pp_numId, pp_lvl_el = self.get_numId_lvl_for_p(pp, styles_cache)
+                pp_ilvl = pp_lvl_el.ilvl
+                if pp_numId == 0:   # numbering removed (not displayed) for particular para
                     continue
-                if ilvl > pp_ilvl:
+                if ilvl > pp_ilvl and (numId == pp_numId or pp.pPr.pStyle.val in linked_styles):
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1
@@ -263,6 +281,7 @@ class CT_Lvl(BaseOxmlElement):
     ilvl = RequiredAttribute('w:ilvl', ST_DecimalNumber)
     start = ZeroOrOne('w:start', CT_DecimalNumber)
     pPr = ZeroOrOne('w:pPr', CT_PPr)
+    pStyle = ZeroOrOne('w:pStyle', CT_String)
     numFmt = ZeroOrOne('w:numFmt')
     lvlText = ZeroOrOne('w:lvlText')
     suff = ZeroOrOne('w:suff')

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,19 +91,6 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, styles_cache):
-        """
-        Returns ``numPr`` for paragraph if any, otherwise returns related
-        paragraph style ``numPr`` if exists or ``None`` otherwise.
-        """
-        if self.numPr is not None:
-            return self.numPr
-        else:
-            try:
-                return styles_cache[self.pStyle.val].pPr.numPr
-            except (KeyError, AttributeError):
-                return None
-
     @property
     def ind_left(self):
         """


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

changeset:
  - fixed autonumbering bug (_if paragraph has some paragraph style associated in numbering scheme on any level above for the given paragraph, numbering count should restart when paragraph with that associated paragraph style occurs_). 

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
