### PR TITLE
feature/autonumbering update

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -142,7 +142,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_numPr(p.pPr.pStyle.val, styles_cache)
+        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -152,7 +152,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Returns list item for the given paragraph.
         """
-        numPr = p.pPr.get_numPr(p.pPr.pStyle.val, styles_cache)
+        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -163,7 +163,7 @@ class CT_Numbering(BaseOxmlElement):
 
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_numPr = pp.pPr.get_numPr(pp.pPr.pStyle.val, styles_cache)
+                pp_numPr = pp.pPr.get_numPr(pp.pPr, styles_cache)
                 pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
                 pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
                 if pp_numId == 0:

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -142,7 +142,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
+        numPr = p.pPr.get_numPr(styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -152,7 +152,7 @@ class CT_Numbering(BaseOxmlElement):
         """
         Returns list item for the given paragraph.
         """
-        numPr = p.pPr.get_numPr(p.pPr, styles_cache)
+        numPr = p.pPr.get_numPr(styles_cache)
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)
@@ -163,7 +163,7 @@ class CT_Numbering(BaseOxmlElement):
 
         for pp in p.itersiblings(preceding=True):
             try:
-                pp_numPr = pp.pPr.get_numPr(pp.pPr, styles_cache)
+                pp_numPr = pp.pPr.get_numPr(styles_cache)
                 pp_ilvl, pp_numId = pp_numPr.ilvl, pp_numPr.numId.val
                 pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
                 if pp_numId == 0:
@@ -206,7 +206,6 @@ class CT_Numbering(BaseOxmlElement):
             if num not in num_ids:
                 break
         return num
-
 
 class CT_AbstractNum(BaseOxmlElement):
     """

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,16 +91,16 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, pPr, styles_cache):
+    def get_numPr(self, styles_cache):
         """
         Returns ``numPr`` for paragraph if any, otherwise returns related
         paragraph style ``numPr`` if exists or ``None`` otherwise.
         """
-        if pPr.numPr is not None:
-            return pPr.numPr
+        if self.numPr is not None:
+            return self.numPr
         else:
             try:
-                return styles_cache[pPr.pStyle.val].pPr.numPr
+                return styles_cache[self.pStyle.val].pPr.numPr
             except (KeyError, AttributeError):
                 return None
 

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,19 +91,6 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, styles_cache):
-        """
-        Returns ``numPr`` for paragraph if any, otherwise returns related
-        paragraph style ``numPr`` if exists or ``None`` otherwise.
-        """
-        if self.numPr is not None:
-            return self.numPr
-        else:
-            try:
-                return styles_cache[self.pStyle.val].pPr.numPr
-            except (KeyError, AttributeError):
-                return None
-
     @property
     def ind_left(self):
         """

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -91,17 +91,17 @@ class CT_PPr(BaseOxmlElement):
         else:
             ind.firstLine = value
 
-    def get_numPr(self, style_id, styles_cache):
+    def get_numPr(self, pPr, styles_cache):
         """
         Returns ``numPr`` for paragraph if any, otherwise returns related
         paragraph style ``numPr`` if exists or ``None`` otherwise.
         """
-        if self.numPr is not None:
-            return self.numPr
+        if pPr.numPr is not None:
+            return pPr.numPr
         else:
             try:
-                return styles_cache[style_id].pPr.numPr
-            except KeyError:
+                return styles_cache[pPr.pStyle.val].pPr.numPr
+            except (KeyError, AttributeError):
                 return None
 
     @property


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- fixed autonumbering bug (if paragraph has some paragraph style associated in numbering scheme on any level above for the given paragraph, numbering count should restart when paragraph with that associated paragraph style occurs).

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
