### PR TITLE
merging `list-item-indent` feature into `autonumbering` 

### DIFF
--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -12,7 +12,6 @@ from .oxml.table import CT_Tbl
 from .shared import Parented
 from .text.paragraph import Paragraph
 
-
 class BlockItemContainer(Parented):
     """
     Base class for proxy objects that can contain block items, such as _Body,
@@ -24,18 +23,22 @@ class BlockItemContainer(Parented):
         super(BlockItemContainer, self).__init__(parent)
         self._element = element
 
-    def add_paragraph(self, text='', style=None):
+    def add_paragraph(self, text='', style=None, prev=None, ilvl=None):
         """
         Return a paragraph newly added to the end of the content in this
         container, having *text* in a single run if present, and having
         paragraph style *style*. If *style* is |None|, no paragraph style is
         applied, which has the same effect as applying the 'Normal' style.
+        If paragraph is part of numbered list then ``prev_p`` (previous para)
+        and ``ilvl``(indentation level) should be specified.
         """
         paragraph = self._add_paragraph()
         if text:
             paragraph.add_run(text)
         if style is not None:
             paragraph.style = style
+        if prev is not None or ilvl is not None:
+            paragraph.set_li_lvl(self.part.styles, prev, ilvl)
         return paragraph
 
     def add_table(self, rows, cols, width):

--- a/docx/document.py
+++ b/docx/document.py
@@ -21,7 +21,7 @@ class Document(ElementProxy):
     Use :func:`docx.Document` to open or create a document.
     """
 
-    __slots__ = ('_part', '__body')
+    #__slots__ = ('_part', '__body')
 
     def __init__(self, element, part):
         super(Document, self).__init__(element)
@@ -51,16 +51,17 @@ class Document(ElementProxy):
         paragraph.add_run().add_break(WD_BREAK.PAGE)
         return paragraph
 
-    def add_paragraph(self, text='', style=None):
+    def add_paragraph(self, text='', style=None, prev_p=None, ilvl=None):
         """
         Return a paragraph newly added to the end of the document, populated
         with *text* and having paragraph style *style*. *text* can contain
         tab (``\\t``) characters, which are converted to the appropriate XML
         form for a tab. *text* can also include newline (``\\n``) or carriage
         return (``\\r``) characters, each of which is converted to a line
-        break.
+        break. If paragraph is part of numbered list then ``prev_p`` (previous para)
+        and ``ilvl``(indentation level) should be specified.
         """
-        return self._body.add_paragraph(text, style)
+        return self._body.add_paragraph(text, style, prev_p, ilvl)
 
     def add_picture(self, image_path_or_stream, width=None, height=None):
         """

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -225,6 +225,32 @@ class CT_Numbering(BaseOxmlElement):
                 break
         return num
 
+    def set_li_lvl(self, para_el, styles, prev_p, ilvl):
+        """
+        Sets paragraph list item indentation level. When previous
+        paragraph ``prev_p`` is specified, it will look up for existing numbering
+        list of ``prev_p`` and add new list item. If no ``prev_p`` is specified,
+        it will create a new numbering list with specified indentation level ``ilvl``.
+        """
+        if (prev_p is None or
+                prev_p.pPr is None or
+                prev_p.pPr.numPr is None or
+                prev_p.pPr.numPr.numId is None):
+            if ilvl is None:
+                ilvl = 0
+            numId, _ = self.get_numId_lvl_for_p(para_el, styles)
+            num_el = self.num_having_numId(numId)
+            anum = num_el.abstractNumId.val
+            num = self.add_num(anum)
+            num.add_lvlOverride(ilvl=ilvl).add_startOverride(1)
+            num = num.numId
+        else:
+            if ilvl is None:
+                ilvl = prev_p.pPr.numPr.ilvl.val
+            num = prev_p.pPr.numPr.numId.val
+        para_el.get_or_add_pPr().get_or_add_numPr().get_or_add_numId().val = num
+        para_el.get_or_add_pPr().get_or_add_numPr().get_or_add_ilvl().val = ilvl
+
 class CT_AbstractNum(BaseOxmlElement):
     """
     ``<w:abstractNum>`` element, contains definitions for numbering part.

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -72,6 +72,12 @@ class CT_P(BaseOxmlElement):
         pPr._remove_sectPr()
         pPr._insert_sectPr(sectPr)
 
+    def set_li_lvl(self, numbering_el, styles_el, prev_el, ilvl):
+        """
+        Sets list indentation level for this paragraph.
+        """
+        numbering_el.set_li_lvl(self, styles_el, prev_el, ilvl)
+
     @property
     def style(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -13,7 +13,6 @@ from .parfmt import ParagraphFormat
 from .run import Run
 from ..shared import Parented
 
-
 class Paragraph(Parented):
     """
     Proxy object wrapping ``<w:p>`` element.
@@ -65,7 +64,7 @@ class Paragraph(Parented):
         self._p.clear_content()
         return self
 
-    def insert_paragraph_before(self, text=None, style=None):
+    def insert_paragraph_before(self, text=None, style=None, ilvl=None):
         """
         Return a newly created paragraph, inserted directly before this
         paragraph. If *text* is supplied, the new paragraph contains that
@@ -77,6 +76,8 @@ class Paragraph(Parented):
             paragraph.add_run(text)
         if style is not None:
             paragraph.style = style
+        if ilvl is not None:
+            paragraph.set_li_lvl(self.part.styles, self, ilvl)
         return paragraph
 
     @property
@@ -156,6 +157,17 @@ class Paragraph(Parented):
             style_or_name, WD_STYLE_TYPE.PARAGRAPH
         )
         self._p.style = style_id
+
+    def set_li_lvl(self, styles, prev, ilvl):
+        """
+        Sets list indentation level for this paragraph. If ``prev`` is not specified
+        it starts a new list. ``ilvl`` specifies indentation level. Default
+        indentation level is 0.
+        """
+        prev_el = prev._element if prev else None
+        _ilvl = 0 if ilvl is None else ilvl
+        self._p.set_li_lvl(self.part.numbering_part._element,
+                              self.part.cached_styles, prev_el, _ilvl)
 
     @property
     def text(self):

--- a/docx/text/run.py
+++ b/docx/text/run.py
@@ -181,7 +181,6 @@ class Run(Parented):
     def underline(self, value):
         self.font.underline = value
 
-
 class _Text(object):
     """
     Proxy object wrapping ``<w:t>`` element.


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- added support for writing numbered paragraphs by extending
`add_paragraph` method with following parameters:
  * custom stlye
  * custom `ilvl` indentation level
  * custom paragraph position within numbered list by specifying
   `prev_p` paragraph

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
