### PR TITLE
merge autonumbering to merge all

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.8.5'
+__version__ = '0.8.8.6'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -243,8 +243,7 @@ class CT_Numbering(BaseOxmlElement):
                 prev_p.pPr.numPr.numId is None):
             if ilvl is None:
                 ilvl = 0
-            numPr = para_el.pPr.get_numPr(styles)
-            numId = numPr.numId.val
+            numId, _ = self.get_numId_lvl_for_p(para_el, styles)
             num_el = self.num_having_numId(numId)
             anum = num_el.abstractNumId.val
             num = self.add_num(anum)

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -303,6 +303,17 @@ class Paragraph(Parented, BookmarkParent):
         else:
             return ''
 
+    def set_li_lvl(self, styles, prev, ilvl):
+        """
+        Sets list indentation level for this paragraph. If ``prev`` is not specified
+        it starts a new list. ``ilvl`` specifies indentation level. Default
+        indentation level is 0.
+        """
+        prev_el = prev._element if prev else None
+        _ilvl = 0 if ilvl is None else ilvl
+        self._p.set_li_lvl(self.part.numbering_part._element,
+                              self.part.cached_styles, prev_el, _ilvl)
+
     @property
     @cache
     def text(self):


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- releasing autonumbering bug fix and refactoring (now autonumbering handles linked paragraph styles defined within numbering scheme)

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
