### PR TITLE
autonumbering merge all update

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.8.5'
+__version__ = '0.8.8.6'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -164,6 +164,8 @@ class CT_Numbering(BaseOxmlElement):
         if abstractNum_el is None:
             return None
         lvl_el = abstractNum_el.get_lvl(ilvl)
+        linked_styles = {s.xpath('w:pStyle/@w:val')[0]
+            for s in lvl_el.xpath('preceding-sibling::w:lvl[w:pStyle]')}
         p_num = int(lvl_el.start.get('{%s}val' % nsmap['w']))
 
         for pp in p.itersiblings(preceding=True):
@@ -173,7 +175,7 @@ class CT_Numbering(BaseOxmlElement):
                 pp_ilvl = pp_ilvl.val if pp_ilvl is not None else 0
                 if pp_numId == 0:
                     continue
-                if ilvl > pp_ilvl:
+                if ilvl > pp_ilvl and (numId == pp_numId or pp.pPr.pStyle.val in linked_styles):
                     break
                 if (pp_ilvl, pp_numId) == (ilvl, numId):
                     p_num += 1

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -303,6 +303,17 @@ class Paragraph(Parented, BookmarkParent):
         else:
             return ''
 
+    def set_li_lvl(self, styles, prev, ilvl):
+        """
+        Sets list indentation level for this paragraph. If ``prev`` is not specified
+        it starts a new list. ``ilvl`` specifies indentation level. Default
+        indentation level is 0.
+        """
+        prev_el = prev._element if prev else None
+        _ilvl = 0 if ilvl is None else ilvl
+        self._p.set_li_lvl(self.part.numbering_part._element,
+                              self.part.cached_styles, prev_el, _ilvl)
+
     @property
     @cache
     def text(self):


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)



## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
