### PR TITLE
 ms word fields support

### DIFF
--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -196,7 +196,8 @@ register_element_cls('w:tab',             CT_TabStop)
 register_element_cls('w:tabs',            CT_TabStops)
 register_element_cls('w:widowControl',    CT_OnOff)
 
-from .text.run import CT_Br, CT_R, CT_Text
+from .text.run import CT_Br, CT_R, CT_Text, CT_FldChar
 register_element_cls('w:br', CT_Br)
 register_element_cls('w:r',  CT_R)
 register_element_cls('w:t',  CT_Text)
+register_element_cls('w:fldChr', CT_FldChar)

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -29,6 +29,8 @@ class CT_R(BaseOxmlElement):
     cr = ZeroOrMore('w:cr')
     tab = ZeroOrMore('w:tab')
     drawing = ZeroOrMore('w:drawing')
+    fldChar = ZeroOrMore('w:fldChar')
+    instrText = ZeroOrMore('w:instrText')
 
     def _insert_rPr(self, rPr):
         self.insert(0, rPr)
@@ -109,6 +111,13 @@ class CT_Text(BaseOxmlElement):
     ``<w:t>`` element, containing a sequence of characters within a run.
     """
 
+class CT_FldChar(BaseOxmlElement):
+    """
+    ``<w:fldChr>`` element, containing properties related to field.
+    """
+    fldData = ZeroOrOne('w:fldData')
+    ffData = ZeroOrOne('w:ffData')
+    numberingChange = ZeroOrOne('w:numberingChange')
 
 class _RunContentAppender(object):
     """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -39,6 +39,16 @@ class Paragraph(Parented):
             run.style = style
         return run
 
+    def add_field(self, instrText=None):
+        """
+        Adds new field `w:fldChar` to run. Pass `instrText` to specify
+        filed instruction.
+        """
+        self.add_run().add_fldChar()
+        if instrText:
+            self.add_run().add_instrText(instrText)
+        self.add_run().add_fldChar(fldCharType='end')
+
     @property
     def alignment(self):
         """

--- a/docx/text/run.py
+++ b/docx/text/run.py
@@ -80,6 +80,22 @@ class Run(Parented):
         t = self._r.add_t(text)
         return _Text(t)
 
+    def add_fldChar(self, fldCharType="begin"):
+        """
+        Adds new ``<w:fldChar>`` element with specified ``w:fldCharType`` attr.
+        Available options for ``w:fldCharType`` attr are `('begin', 'separate', 'end')`.
+        """
+        fldChar = self._r.add_fldChar()
+        fldChar.set('{%s}fldCharType' % fldChar.nsmap['w'], fldCharType)
+
+    def add_instrText(self, instruction_text):
+        """
+        Adds new ``<w:instrText>`` element with specified instruction text
+        `instrText`. It represents instruction for related ``<w:fldChar>``.
+        """
+        instrText = self._r.add_instrText()
+        instrText.text = instruction_text
+
     @property
     def bold(self):
         """


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- extended library with support for work with ms word fileds
- extended paragraph and run classes with related methods
- registered `w:fldChar` and `w:instrText`, and provided
related handlers


## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
