### PR TITLE
merge vector graphics

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.2'
+__version__ = '0.8.10.3'
 
 
 # register custom Part classes with opc package reader

--- a/docx/image/__init__.py
+++ b/docx/image/__init__.py
@@ -14,6 +14,7 @@ from docx.image.gif import Gif
 from docx.image.jpeg import Exif, Jfif
 from docx.image.png import Png
 from docx.image.tiff import Tiff
+from docx.image.emf import Emf
 
 
 SIGNATURES = (
@@ -26,4 +27,5 @@ SIGNATURES = (
     (Tiff, 0, b'MM\x00*'),  # big-endian (Motorola) TIFF
     (Tiff, 0, b'II*\x00'),  # little-endian (Intel) TIFF
     (Bmp,  0, b'BM'),
+    (Emf,  40, b' EMF'),
 )

--- a/docx/image/constants.py
+++ b/docx/image/constants.py
@@ -102,6 +102,7 @@ class MIME_TYPE(object):
     JPEG = 'image/jpeg'
     PNG = 'image/png'
     TIFF = 'image/tiff'
+    EMF = 'image/emf'
 
 
 class PNG_CHUNK_TYPE(object):

--- a/docx/image/emf.py
+++ b/docx/image/emf.py
@@ -1,0 +1,70 @@
+# encoding: utf-8
+
+from __future__ import absolute_import, division, print_function
+
+from .constants import MIME_TYPE
+from .exceptions import InvalidImageStreamError
+from .helpers import BIG_ENDIAN, StreamReader
+from .image import BaseImageHeader
+import struct
+
+class Emf(BaseImageHeader):
+    """
+    Image header parser for PNG images
+    """
+    @property
+    def content_type(self):
+        """
+        MIME content type for this image, unconditionally `image/png` for
+        PNG images.
+        """
+        return MIME_TYPE.EMF
+
+    @property
+    def default_ext(self):
+        """
+        Default filename extension, always 'png' for PNG images.
+        """
+        return 'emf'
+
+    @classmethod
+    def from_stream(cls, stream,filename=None):
+        """
+        Return a |Emf| instance having header properties parsed from image in
+        *stream*.
+        """
+
+        """
+        @0 DWORD iType; // fixed
+        @4 DWORD nSize; // var
+        @8 RECTL rclBounds;
+        @24 RECTL rclFrame; // .01 millimeter units L T R B
+        @40 DWORD dSignature; // ENHMETA_SIGNATURE = 0x464D4520
+        DWORD nVersion;
+        DWORD nBytes;
+        DWORD nRecords;
+        WORD  nHandles;
+        WORD  sReserved;
+        DWORD nDescription;
+        DWORD offDescription;
+        DWORD nPalEntries;
+        SIZEL szlDevice;
+        SIZEL szlMillimeters;
+        """
+        stream.seek(0)
+        x = stream.read(40)
+        stream.seek(0)
+        iType,nSize = struct.unpack("ii",x[0:8])
+        rclBounds = struct.unpack("iiii",x[8:24])
+        rclFrame = struct.unpack("iiii",x[24:40])
+
+        dpi = 300
+        horz_dpi = dpi
+        vert_dpi = dpi
+        mmwidth = (rclFrame[2]-rclFrame[0])/100.0
+        mmheight = (rclFrame[3]-rclFrame[1])/100.0
+        px_width = int(mmwidth*dpi*0.03937008)
+        px_height = int(mmheight*dpi*0.03937008)
+
+        #1 dot/inch  =  0.03937008 pixel/millimeter
+        return cls(px_width,px_height,horz_dpi,vert_dpi)

--- a/docx/image/image.py
+++ b/docx/image/image.py
@@ -187,11 +187,11 @@ def _ImageHeaderFactory(stream):
     """
     from docx.image import SIGNATURES
 
-    def read_32(stream):
+    def read_64(stream):
         stream.seek(0)
-        return stream.read(32)
+        return stream.read(64)
 
-    header = read_32(stream)
+    header = read_64(stream)
     for cls, offset, signature_bytes in SIGNATURES:
         end = offset + len(signature_bytes)
         found_bytes = header[offset:end]


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- implemented WMF support for python-docx based on existing PR
python-openxml#196
- bump to `0.8.10.3`

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
