### PR TITLE
feat: added flag to check if cctrol is empty

### DIFF
--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -33,6 +33,7 @@ class CT_SdtPr(BaseOxmlElement):
     """
     tag = ZeroOrOne('w:tag')
     date = ZeroOrOne('w:date')
+    active_placeholder = ZeroOrOne('w:showingPlcHdr')
 
     @property
     def name(self):

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -23,6 +23,11 @@ class SdtBase(ElementProxy):
         return SdtPr(self._element.sdtPr, self)
 
     @property
+    def is_empty(self):
+        return any((self.properties.active_placeholder,
+                    not self.content.text))
+
+    @property
     def name(self):
         return self.properties.name
 
@@ -37,6 +42,10 @@ class SdtPr(ElementProxy):
     @property
     def name(self):
         return self._element.name
+
+    @property
+    def active_placeholder(self):
+        return self._element.active_placeholder is not None
 
 class SdtContentBase(ElementProxy):
     """


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

added indicator for checking if content control is empty.
refs:
http://www.datypic.com/sc/ooxml/t-w_CT_SdtPr.html 
http://www.datypic.com/sc/ooxml/e-w_showingPlcHdr-1.html

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
