### PR TITLE
abc collections compatibility

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.6'
+__version__ = '0.8.10.7'
 
 
 # register custom Part classes with opc package reader

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -15,7 +15,6 @@ from .text.paragraph import Paragraph
 from .sdt import SdtBase
 from docx.bookmark import BookmarkParent
 
-
 class BlockItemContainer(Parented, BookmarkParent):
     """
     Base class for proxy objects that can contain block items, such as _Body,

--- a/docx/bookmark.py
+++ b/docx/bookmark.py
@@ -5,9 +5,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 try:
-    from collections import Sequence
-except DeprecationWarning:
     from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from itertools import chain
 

--- a/docx/bookmark.py
+++ b/docx/bookmark.py
@@ -4,7 +4,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import Sequence
+try:
+    from collections import Sequence
+except DeprecationWarning:
+    from collections.abc import Sequence
+
 from itertools import chain
 
 from docx.oxml.ns import qn

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -207,9 +207,14 @@ from .bookmark import (
 register_element_cls('w:bookmarkStart', CT_BookmarkStart)
 register_element_cls('w:bookmarkEnd', CT_BookmarkEnd)
 
-from .text.font import (
-    CT_Color, CT_Fonts, CT_Highlight, CT_HpsMeasure, CT_RPr, CT_Underline,
-    CT_VerticalAlignRun
+from .text.font import (  # noqa
+    CT_Color,
+    CT_Fonts,
+    CT_Highlight,
+    CT_HpsMeasure,
+    CT_RPr,
+    CT_Underline,
+    CT_VerticalAlignRun,
 )
 register_element_cls('w:b',          CT_OnOff)
 register_element_cls('w:bCs',        CT_OnOff)

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -4,9 +4,7 @@
 |DocumentPart| and closely related objects
 """
 
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals
-)
+from __future__ import absolute_import, division, print_function, unicode_literals
 from itertools import chain
 from docx.document import Document
 from docx.opc.constants import RELATIONSHIP_TYPE as RT


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)



## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
