### PR TITLE
write cctrl feature

### DIFF
--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -98,5 +98,12 @@ class BlockItemContainer(Parented):
 
     def _iter_sdts_all(self):
         nsmap = self._element.nsmap
+        sections = self._parent.sections
+        for s in sections:
+            hdr_ftrs = (s.header, s.first_page_header, s.even_page_header,
+                        s.footer, s.first_page_footer, s.even_page_footer)
+            for hdr_ftr in hdr_ftrs:
+                for sdt in hdr_ftr._element.iterdescendants('{%s}sdt' % nsmap['w']):
+                    yield sdt, sdt.name
         for sdt in self._element.iterdescendants('{%s}sdt' % nsmap['w']):
             yield sdt, sdt.name

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -15,10 +15,10 @@ class CT_SdtBase(BaseOxmlElement):
     ``<w:sdt>`` structured document tag element (content control)
     specifies content control elements on any level of document.
     """
-    _tag_seq = ('w:sdtPr', 'w:stEndPr', 'w:sdtContent')
+    _tag_seq = ('w:sdtPr', 'w:sdtEndPr', 'w:sdtContent')
 
     sdtPr = ZeroOrOne('w:sdtPr', successors=_tag_seq[1:])
-    stEndPr = ZeroOrOne('w:stEndPr', successors=_tag_seq[2:])
+    sdtEndPr = ZeroOrOne('w:sdtEndPr', successors=_tag_seq[2:])
     sdtContent = ZeroOrOne('w:sdtContent', successors=())
 
     del _tag_seq
@@ -31,14 +31,18 @@ class CT_SdtPr(BaseOxmlElement):
     """
     ``<w:sdtPr>`` represents property element of ``<w:sdt>`` (content control).
     """
-    tag = ZeroOrOne('w:tag')
-    date = ZeroOrOne('w:date')
+    alias = ZeroOrOne('w:alias')
+    lock = ZeroOrOne('w:lock')
+    placeholder = ZeroOrOne('w:placeholder')
+    temporary = ZeroOrOne('w:temporary')
+    tag_name = ZeroOrOne('w:tag')
     active_placeholder = ZeroOrOne('w:showingPlcHdr')
+    rPr = ZeroOrOne('w:rPr')
 
     @property
     def name(self):
         try:
-            return self.tag.get('{%s}val' % nsmap['w'])
+            return self.tag_name.get('{%s}val' % nsmap['w'])
         except AttributeError:
             return None
 
@@ -49,6 +53,7 @@ class CT_SdtContentBase(BaseOxmlElement):
     It contains all paragraphs within the content control.
     """
     p = ZeroOrMore('w:p')
+    r = ZeroOrMore('w:r')
 
     def iter_runs(self):
         def walk(el):

--- a/docx/oxml/table.py
+++ b/docx/oxml/table.py
@@ -759,7 +759,6 @@ class CT_TcPr(BaseOxmlElement):
         'w:cellDel', 'w:cellMerge', 'w:tcPrChange'
     )
     tcW = ZeroOrOne('w:tcW', successors=_tag_seq[2:])
-    tcBorders = ZeroOrOne('w:tcBorders', successors=_tag_seq[6:])
     gridSpan = ZeroOrOne('w:gridSpan', successors=_tag_seq[3:])
     vMerge = ZeroOrOne('w:vMerge', successors=_tag_seq[5:])
     vAlign = ZeroOrOne('w:vAlign', successors=_tag_seq[12:])

--- a/docx/oxml/table.py
+++ b/docx/oxml/table.py
@@ -759,6 +759,7 @@ class CT_TcPr(BaseOxmlElement):
         'w:cellDel', 'w:cellMerge', 'w:tcPrChange'
     )
     tcW = ZeroOrOne('w:tcW', successors=_tag_seq[2:])
+    tcBorders = ZeroOrOne('w:tcBorders', successors=_tag_seq[6:])
     gridSpan = ZeroOrOne('w:gridSpan', successors=_tag_seq[3:])
     vMerge = ZeroOrOne('w:vMerge', successors=_tag_seq[5:])
     vAlign = ZeroOrOne('w:vAlign', successors=_tag_seq[12:])

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -54,7 +54,7 @@ class SdtPr(ElementProxy):
 
     @property
     def tag(self):
-        return self._element.tag
+        return self._element.name
 
     @property
     def active_placeholder(self):

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -2,8 +2,21 @@
 |SdtBase| and closely related objects.
 """
 
+import docx.text.paragraph
+
 from .shared import ElementProxy
-from .text.paragraph import Paragraph
+
+from enum import Enum, auto
+
+class SdtType(Enum):
+    """
+    Initial list of available Structure Document Types
+    """
+    RICH_TEXT = auto(),
+    PLAIN_TEXT = auto(),
+    DATE = auto(),
+    DROP_DOWN = auto(),
+
 
 class SdtBase(ElementProxy):
     """
@@ -29,7 +42,7 @@ class SdtBase(ElementProxy):
 
     @property
     def name(self):
-        return self.properties.name
+        return self.properties.tag
 
 class SdtPr(ElementProxy):
     """
@@ -40,8 +53,8 @@ class SdtPr(ElementProxy):
         super(SdtPr, self).__init__(element, parent)
 
     @property
-    def name(self):
-        return self._element.name
+    def tag(self):
+        return self._element.tag
 
     @property
     def active_placeholder(self):
@@ -57,7 +70,7 @@ class SdtContentBase(ElementProxy):
 
     @property
     def paragraphs(self):
-        return [Paragraph(p, self) for p in self._element.p_lst]
+        return [docx.text.paragraph.Paragraph(p, self) for p in self._element.p_lst]
 
     @property
     def text(self):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -14,7 +14,7 @@ from .parfmt import ParagraphFormat
 from .run import Run
 from ..shared import Parented, lazyproperty
 from ..oxml.ns import nsmap
-from docx.sdt import SdtType
+from docx.sdt import SdtType, SdtBase
 
 class Paragraph(Parented):
     """
@@ -110,7 +110,7 @@ class Paragraph(Parented):
             t.text = text
 
         self._p.append(sdt)
-        return sdt
+        return SdtBase(sdt, self)
 
     @property
     def alignment(self):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -41,16 +41,6 @@ class Paragraph(Parented):
             run.style = style
         return run
 
-    def add_field(self, instrText=None):
-        """
-        Adds new field `w:fldChar` to run. Pass `instrText` to specify
-        filed instruction.
-        """
-        self.add_run().add_fldChar()
-        if instrText:
-            self.add_run().add_instrText(instrText)
-        self.add_run().add_fldChar(fldCharType='end')
-
     def add_sdt(self, tag_name, text='', alias_name='', temporary='false', locked='unlocked',
                 placeholder_txt=None, style='Normal', bold=False, italic=False, type=SdtType.RICH_TEXT):
         """
@@ -67,6 +57,19 @@ class Paragraph(Parented):
             if italic:
                 rPr._add_i()
             # TODO: impl underline
+
+        def set_std_placeholder_text(r, text=None):
+            rPr = r._add_rPr()
+            rStyle = rPr._add_rStyle()
+            rStyle.set('{%s}val' % nsmap['w'], 'PlaceholderText')
+            rPr._add_b()
+            rPr._add_bCs()
+            t = r._add_t()
+            placeholder_txt = text or 'Click or tap here to enter text'
+            t.text = placeholder_txt
+            active_placeholder = sdtPr._add_active_placeholder()
+            active_placeholder.set('{%s}val' % nsmap['w'], 'true')
+
 
         sdt = self._p._new_sdt()
 
@@ -88,20 +91,10 @@ class Paragraph(Parented):
 
         sdtContent = sdt._add_sdtContent()
 
+        r = sdtContent._add_r()
         if not text:
-            r = sdtContent._add_r()
-            rPr = r._add_rPr()
-            rStyle = rPr._add_rStyle()
-            rStyle.set('{%s}val' % nsmap['w'], 'PlaceholderText')
-            rPr._add_b()
-            rPr._add_bCs()
-            t = r._add_t()
-            placeholder_txt = placeholder_txt or 'Click or tap here to enter text'
-            t.text = placeholder_txt
-            active_placeholder = sdtPr._add_active_placeholder()
-            active_placeholder.set('{%s}val' % nsmap['w'], 'true')
+            set_std_placeholder_text(r, placeholder_txt)
         else:
-            r = sdtContent._add_r()
             # set styling on content lvl
             rPr = r.get_or_add_rPr()
             apply_run_formatting(rPr, style, bold, italic)

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -13,6 +13,8 @@ from ..enum.style import WD_STYLE_TYPE
 from .parfmt import ParagraphFormat
 from .run import Run
 from ..shared import Parented, lazyproperty
+from ..oxml.ns import nsmap
+from docx.sdt import SdtType
 
 class Paragraph(Parented):
     """
@@ -38,6 +40,77 @@ class Paragraph(Parented):
         if style:
             run.style = style
         return run
+
+    def add_field(self, instrText=None):
+        """
+        Adds new field `w:fldChar` to run. Pass `instrText` to specify
+        filed instruction.
+        """
+        self.add_run().add_fldChar()
+        if instrText:
+            self.add_run().add_instrText(instrText)
+        self.add_run().add_fldChar(fldCharType='end')
+
+    def add_sdt(self, tag_name, text='', alias_name='', temporary='false', locked='unlocked',
+                placeholder_txt=None, style='Normal', bold=False, italic=False, type=SdtType.RICH_TEXT):
+        """
+        Adds new Structured Document Type ``w:sdt`` field to the Paragraph element.
+        """
+
+        def apply_run_formatting(rPr, style='Normal', bold=False, italic=False, underline=False):
+            if style != 'Normal':
+                rStyle = rPr._add_rStyle()
+                rStyle.set('{%s}val' % nsmap['w'], style)
+            if bold:
+                rPr._add_b()
+                rPr._add_bCs()
+            if italic:
+                rPr._add_i()
+            # TODO: impl underline
+
+        sdt = self._p._new_sdt()
+
+        sdtPr = sdt._add_sdtPr()
+        alias_name = alias_name or tag_name
+
+        # set styling on sdt lvl
+        rPr = sdtPr.get_or_add_rPr()
+        apply_run_formatting(rPr, style, bold, italic)
+
+        tag = sdtPr._add_tag_name()
+        tag.set('{%s}val' % nsmap['w'], tag_name)
+
+        alias = sdtPr._add_alias()
+        alias.set('{%s}val' % nsmap['w'], alias_name)
+
+        temp = sdtPr._add_temporary()
+        temp.set('{%s}val' % nsmap['w'], temporary)
+
+        sdtContent = sdt._add_sdtContent()
+
+        if not text:
+            r = sdtContent._add_r()
+            rPr = r._add_rPr()
+            rStyle = rPr._add_rStyle()
+            rStyle.set('{%s}val' % nsmap['w'], 'PlaceholderText')
+            rPr._add_b()
+            rPr._add_bCs()
+            t = r._add_t()
+            placeholder_txt = placeholder_txt or 'Click or tap here to enter text'
+            t.text = placeholder_txt
+            active_placeholder = sdtPr._add_active_placeholder()
+            active_placeholder.set('{%s}val' % nsmap['w'], 'true')
+        else:
+            r = sdtContent._add_r()
+            # set styling on content lvl
+            rPr = r.get_or_add_rPr()
+            apply_run_formatting(rPr, style, bold, italic)
+
+            t = r._add_t()
+            t.text = text
+
+        self._p.append(sdt)
+        return sdt
 
     @property
     def alignment(self):


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

- added support for adding content controls
- enabled access towards content controls within header and footer parts

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
