### PR TITLE
Handle Smart Tags

### DIFF
--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -55,6 +55,8 @@ class CT_SdtContentBase(BaseOxmlElement):
             for child in el:
                 if child.tag == qn('w:r'):
                     yield child
+                elif child.tag in (qn('w:smartTag'),):
+                    yield from get_runs(child)                    
                 else:
                     yield from walk(child)
         yield from walk(self)

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -108,6 +108,6 @@ class CT_P(BaseOxmlElement):
             for child in elem:
                 if child.tag == qn('w:r'):
                     yield child
-                elif child.tag in (qn('w:hyperlink'), qn('w:sdt'), qn('w:sdtContent')):
+                elif child.tag in (qn('w:hyperlink'), qn('w:sdt'), qn('w:sdtContent'), qn('w:smartTag'),):
                     yield from get_runs(child)
         yield from get_runs(self)


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)
Smart Tags are a docx feature that allow you to label text and take
special actions with it (e.g. you can Smart Tag a name so that you
can add it to your outlook contacts from word).

We don't need this info, but the Smart Tagged text is wrapped in an
extra xml element: w:smartTag and is preventing the child run from
being processed. Now the runs inside of the w:smartTag are yielded.


## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
