### PR TITLE
Fix for calculating tab-based indent

### DIFF
--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -478,7 +478,8 @@ class Paragraph(Parented):
                  or round(get_attr_with_style(self, 'first_line_indent').inches, 2)) + left_indent
 
             # Find out the number of tabs at the beginning of the paragraph.
-            tab_count = len(self.text) - len(self.text.lstrip('\t'))
+            # Ignore regular spaces.
+            tab_count = self.text[:len(self.text) - len(self.text.lstrip())].count('\t')
 
             if tab_count:
 


### PR DESCRIPTION
See https://github.com/openlawlibrary/platform/issues/2717

This is a fix in the mixed spaces indent support. 
There was a bug when tabs and spaces were mixed.

This change ignores spaces and just count number of tabs.