### PR TITLE
Extend SDTs to support paragraphs, other sdts, tables and runs

### DIFF
--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -51,15 +51,19 @@ class BlockItemContainer(Parented):
         self._element._insert_tbl(tbl)
         return Table(tbl, self)
 
-    def add_sdt(self, tag_name):
+    def add_sdt(self, tag_name, alias_name=''):
         """
         Returns Rich Text Content Control with given *tag_name*.
         Appends created content control to the content in this container.
         """
         from .sdt import SdtBase
         sdt = self._element._new_sdt()
+
         sdtPr = sdt._add_sdtPr()
         sdtPr.name = tag_name
+        alias_name = alias_name or tag_name
+        sdtPr.alias_val = alias_name
+
         sdt._add_sdtContent()
         self._element.append(sdt)
         return SdtBase(sdt, self)

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -50,6 +50,19 @@ class BlockItemContainer(Parented):
         self._element._insert_tbl(tbl)
         return Table(tbl, self)
 
+    def add_sdt(self, tag_name):
+        """
+        Returns Rich Text Content Control with given *tag_name*.
+        Appends created content control to the content in this container.
+        """
+        from .sdt import SdtBase
+        sdt = self._element._new_sdt()
+        sdtPr = sdt._add_sdtPr()
+        sdtPr.name = tag_name
+        sdt._add_sdtContent()
+        self._element.append(sdt)
+        return SdtBase(sdt, self)
+
     @property
     def paragraphs(self):
         """

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -11,8 +11,6 @@ from collections import OrderedDict
 
 from .oxml.table import CT_Tbl
 from .shared import Parented
-from .text.paragraph import Paragraph
-from .sdt import SdtBase
 
 
 class BlockItemContainer(Parented):
@@ -58,6 +56,7 @@ class BlockItemContainer(Parented):
         A list containing the paragraphs in this container, in document
         order. Read-only.
         """
+        from .text.paragraph import Paragraph
         return [Paragraph(p, self) for p in self._element.p_lst]
 
     @property
@@ -66,6 +65,7 @@ class BlockItemContainer(Parented):
         A list of children sdts (content controls) in this container, in
         document order. Read-only.
         """
+        from .sdt import SdtBase
         return OrderedDict({k:SdtBase(s, self) for (s,k) in self._iter_sdts()})
 
     @property
@@ -74,6 +74,7 @@ class BlockItemContainer(Parented):
         A list of descendants sdts (content controls) in this container, in
         document order. Read-only.
         """
+        from .sdt import SdtBase
         return OrderedDict({k:SdtBase(s, self) for (s,k) in self._iter_sdts_all()})
 
     @property
@@ -90,6 +91,7 @@ class BlockItemContainer(Parented):
         Return a paragraph newly added to the end of the content in this
         container.
         """
+        from .text.paragraph import Paragraph
         return Paragraph(self._element.add_p(), self)
 
     def _iter_sdts(self):

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 
 from .oxml.table import CT_Tbl
 from .shared import Parented
+from .text.paragraph import Paragraph
 
 
 class BlockItemContainer(Parented):
@@ -69,7 +70,6 @@ class BlockItemContainer(Parented):
         A list containing the paragraphs in this container, in document
         order. Read-only.
         """
-        from .text.paragraph import Paragraph
         return [Paragraph(p, self) for p in self._element.p_lst]
 
     @property
@@ -104,7 +104,6 @@ class BlockItemContainer(Parented):
         Return a paragraph newly added to the end of the content in this
         container.
         """
-        from .text.paragraph import Paragraph
         return Paragraph(self._element.add_p(), self)
 
     def _iter_sdts(self):

--- a/docx/document.py
+++ b/docx/document.py
@@ -154,6 +154,9 @@ class Document(ElementProxy):
         """
         return self._part.styles
 
+    def add_sdt(self, tag_name):
+        return self._body.add_sdt(tag_name)
+
     @property
     def sdts(self):
         """

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -31,10 +31,10 @@ class CT_SdtPr(BaseOxmlElement):
     """
     ``<w:sdtPr>`` represents property element of ``<w:sdt>`` (content control).
     """
-    alias = ZeroOrOne('w:alias')
+    _alias = ZeroOrOne('w:alias')
     lock = ZeroOrOne('w:lock')
     placeholder = ZeroOrOne('w:placeholder')
-    temporary = ZeroOrOne('w:temporary')
+    _temporary = ZeroOrOne('w:temporary')
     tag_name = ZeroOrOne('w:tag')
     active_placeholder = ZeroOrOne('w:showingPlcHdr')
     rPr = ZeroOrOne('w:rPr')
@@ -46,6 +46,28 @@ class CT_SdtPr(BaseOxmlElement):
         except AttributeError:
             return None
 
+    @name.setter
+    def name(self, tag_name):
+        tag = self._add_tag_name()
+        tag.set('{%s}val' % nsmap['w'], tag_name)
+
+    @property
+    def alias(self):
+        return self._alias.get('{%s}val' % nsmap['w'])
+
+    @alias.setter
+    def alias(self, alias_name):
+        alias = self._add__alias()
+        alias.set('{%s}val' % nsmap['w'], alias_name)
+
+    @property
+    def temporary(self):
+        return self._temporary.get('{%s}val' % nsmap['w'])
+
+    @temporary.setter
+    def temporary(self, tmp):
+        temp = self._add__temporary()
+        temp.set(nsmap['w'], tmp)
 
 class CT_SdtContentBase(BaseOxmlElement):
     """

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -76,6 +76,8 @@ class CT_SdtContentBase(BaseOxmlElement):
     """
     p = ZeroOrMore('w:p')
     r = ZeroOrMore('w:r')
+    sdt = ZeroOrMore('w:sdt')
+    tbl = ZeroOrMore('w:tbl')
 
     def iter_runs(self):
         def walk(el):

--- a/docx/oxml/sdts.py
+++ b/docx/oxml/sdts.py
@@ -31,10 +31,10 @@ class CT_SdtPr(BaseOxmlElement):
     """
     ``<w:sdtPr>`` represents property element of ``<w:sdt>`` (content control).
     """
-    _alias = ZeroOrOne('w:alias')
+    alias = ZeroOrOne('w:alias')
     lock = ZeroOrOne('w:lock')
     placeholder = ZeroOrOne('w:placeholder')
-    _temporary = ZeroOrOne('w:temporary')
+    temporary = ZeroOrOne('w:temporary')
     tag_name = ZeroOrOne('w:tag')
     active_placeholder = ZeroOrOne('w:showingPlcHdr')
     rPr = ZeroOrOne('w:rPr')
@@ -52,21 +52,21 @@ class CT_SdtPr(BaseOxmlElement):
         tag.set('{%s}val' % nsmap['w'], tag_name)
 
     @property
-    def alias(self):
-        return self._alias.get('{%s}val' % nsmap['w'])
+    def alias_val(self):
+        return self.alias.get('{%s}val' % nsmap['w'])
 
-    @alias.setter
-    def alias(self, alias_name):
-        alias = self._add__alias()
+    @alias_val.setter
+    def alias_val(self, alias_name):
+        alias = self._add_alias()
         alias.set('{%s}val' % nsmap['w'], alias_name)
 
     @property
-    def temporary(self):
-        return self._temporary.get('{%s}val' % nsmap['w'])
+    def temporary_val(self):
+        return self.temporary.get('{%s}val' % nsmap['w'])
 
-    @temporary.setter
-    def temporary(self, tmp):
-        temp = self._add__temporary()
+    @temporary_val.setter
+    def temporary_val(self, tmp):
+        temp = self._add_temporary()
         temp.set(nsmap['w'], tmp)
 
 class CT_SdtContentBase(BaseOxmlElement):

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -45,6 +45,12 @@ class SdtBase(ElementProxy):
     def name(self):
         return self.properties.tag
 
+    def add_sdt(self, tag_name):
+        return self._content.add_sdt(tag_name)
+
+    @property
+    def sdts(self):
+        return self._content.sdts
 
     def add_paragraph(self, text):
         return self._content.add_paragraph(text)
@@ -52,6 +58,13 @@ class SdtBase(ElementProxy):
     @property
     def paragraphs(self):
         return self._content.paragraphs
+
+    def add_table(self, rows, cols, width):
+        return self._content.add_table(rows, cols, width)
+
+    @property
+    def tables(self):
+        return self._content.tables
 
     @property
     def text(self):

--- a/docx/sdt.py
+++ b/docx/sdt.py
@@ -2,11 +2,9 @@
 |SdtBase| and closely related objects.
 """
 
-import docx.text.paragraph
-
 from .shared import ElementProxy
-
 from enum import Enum, auto
+from .blkcntnr import BlockItemContainer
 
 class SdtType(Enum):
     """
@@ -26,10 +24,13 @@ class SdtBase(ElementProxy):
     """
     def __init__(self, element, parent):
         super(SdtBase, self).__init__(element, parent)
+        self.__content = None
 
     @property
-    def content(self):
-        return SdtContentBase(self._element.sdtContent, self)
+    def _content(self):
+        if self.__content is None:
+            self.__content =_SdtContentBase(self._element.sdtContent, self)
+        return self.__content
 
     @property
     def properties(self):
@@ -38,11 +39,23 @@ class SdtBase(ElementProxy):
     @property
     def is_empty(self):
         return any((self.properties.active_placeholder,
-                    not self.content.text))
+                    not self._content.text))
 
     @property
     def name(self):
         return self.properties.tag
+
+
+    def add_paragraph(self, text):
+        return self._content.add_paragraph(text)
+
+    @property
+    def paragraphs(self):
+        return self._content.paragraphs
+
+    @property
+    def text(self):
+        return self._content.text
 
 class SdtPr(ElementProxy):
     """
@@ -60,17 +73,13 @@ class SdtPr(ElementProxy):
     def active_placeholder(self):
         return self._element.active_placeholder is not None
 
-class SdtContentBase(ElementProxy):
+class _SdtContentBase(BlockItemContainer):
     """
     ``CT_SdtContentBase`` wrapper object, which contains references
     to all paragraphs within the content control, and text property.
     """
     def __init__(self, element, parent):
-        super(SdtContentBase, self).__init__(element, parent)
-
-    @property
-    def paragraphs(self):
-        return [docx.text.paragraph.Paragraph(p, self) for p in self._element.p_lst]
+        super(_SdtContentBase, self).__init__(element, parent)
 
     @property
     def text(self):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -42,9 +42,9 @@ class Paragraph(Parented):
         return run
 
     def add_sdt(self, tag_name, text='', alias_name='', temporary='false', locked='unlocked',
-                placeholder_txt=None, style='Normal', bold=False, italic=False, type=SdtType.RICH_TEXT):
+                placeholder_txt=None, style='Normal', bold=False, italic=False, type=SdtType.PLAIN_TEXT):
         """
-        Adds new Structured Document Type ``w:sdt`` field to the Paragraph element.
+        Adds new Structured Document Type ``w:sdt`` (Plain Text Content Control) field to the Paragraph element.
         """
 
         def apply_run_formatting(rPr, style='Normal', bold=False, italic=False, underline=False):
@@ -80,14 +80,9 @@ class Paragraph(Parented):
         rPr = sdtPr.get_or_add_rPr()
         apply_run_formatting(rPr, style, bold, italic)
 
-        tag = sdtPr._add_tag_name()
-        tag.set('{%s}val' % nsmap['w'], tag_name)
-
-        alias = sdtPr._add_alias()
-        alias.set('{%s}val' % nsmap['w'], alias_name)
-
-        temp = sdtPr._add_temporary()
-        temp.set('{%s}val' % nsmap['w'], temporary)
+        sdtPr.name = tag_name
+        sdtPr.alias = alias_name
+        sdtPr.temp = temporary
 
         sdtContent = sdt._add_sdtContent()
 

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -40,11 +40,12 @@ class Paragraph(Parented):
             run.style = style
         return run
 
-    def add_sdt(self, tag_name, text='', alias_name='', temporary='false', locked='unlocked',
+    def add_sdt(self, tag_name, text='', alias_name='', temporary='false',
                 placeholder_txt=None, style='Normal', bold=False, italic=False):
         """
         Adds new Structured Document Type ``w:sdt`` (Plain Text Content Control) field to the Paragraph element.
         """
+        # TODO: Add support for SdtType and locked property
         from docx.sdt import SdtBase
 
         def apply_run_formatting(rPr, style='Normal', bold=False, italic=False, underline=False):

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -81,8 +81,8 @@ class Paragraph(Parented):
         apply_run_formatting(rPr, style, bold, italic)
 
         sdtPr.name = tag_name
-        sdtPr.alias = alias_name
-        sdtPr.temp = temporary
+        sdtPr.alias_val = alias_name
+        sdtPr.temp_val = temporary
 
         sdtContent = sdt._add_sdtContent()
 

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -14,7 +14,6 @@ from .parfmt import ParagraphFormat
 from .run import Run
 from ..shared import Parented, lazyproperty
 from ..oxml.ns import nsmap
-from docx.sdt import SdtType, SdtBase
 
 class Paragraph(Parented):
     """
@@ -42,10 +41,11 @@ class Paragraph(Parented):
         return run
 
     def add_sdt(self, tag_name, text='', alias_name='', temporary='false', locked='unlocked',
-                placeholder_txt=None, style='Normal', bold=False, italic=False, type=SdtType.PLAIN_TEXT):
+                placeholder_txt=None, style='Normal', bold=False, italic=False):
         """
         Adds new Structured Document Type ``w:sdt`` (Plain Text Content Control) field to the Paragraph element.
         """
+        from docx.sdt import SdtBase
 
         def apply_run_formatting(rPr, style='Normal', bold=False, italic=False, underline=False):
             if style != 'Normal':


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

Earlier implementation only allowed us to create content controls inside paragraphs and fill that control with runs. This PR refactors old code to have more friendlier API and clarifies that content controls inside paragraph are Plain text content controls. Moreover this PR will extend SdtContent to support other sdts, tables, paragraphs and runs. That way the base implementation will be generic for both Plain Text SDTs and for Rich Text SDTs.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
