### PR TITLE
Fix left indentation bug

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -153,7 +153,10 @@ class CT_Numbering(BaseOxmlElement):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.numPr
+        try:
+            numPr = p.pPr.numPr
+        except AttributeError:
+            return None
         if numPr is None:
             return numPr
         ilvl, numId = numPr.ilvl, numPr.numId.val
@@ -165,7 +168,10 @@ class CT_Numbering(BaseOxmlElement):
         """
         Gets the formatting based on current paragraph indentation level.
         """
-        numPr = p.pPr.get_style_numPr(styles_cache)
+        try:
+            numPr = p.pPr.get_style_numPr(styles_cache)
+        except AttributeError:
+            return None
         if numPr is None:
             return numPr
         ilvl, numId = numPr.ilvl, numPr.numId.val

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -148,9 +148,6 @@ class CT_Numbering(BaseOxmlElement):
         try:
             numPr  = p.pPr.get_style_numPr(styles_cache) if styles_cache else p.pPr.numPr
 
-            if numPr is None:
-                raise AttributeError
-
             ilvl, numId = numPr.ilvl, numPr.numId.val
             ilvl = ilvl.val if ilvl is not None else 0
             abstractNum_el = self.get_abstractNum(numId)

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -161,6 +161,18 @@ class CT_Numbering(BaseOxmlElement):
         abstractNum_el = self.get_abstractNum(numId)
         return abstractNum_el.get_lvl(ilvl)
 
+    def get_lvl_from_style_properties(self, p, styles_cache):
+        """
+        Gets the formatting based on current paragraph indentation level.
+        """
+        numPr = p.pPr.get_style_numPr(styles_cache)
+        if numPr is None:
+            return numPr
+        ilvl, numId = numPr.ilvl, numPr.numId.val
+        ilvl = ilvl.val if ilvl is not None else 0
+        abstractNum_el = self.get_abstractNum(numId)
+        return abstractNum_el.get_lvl(ilvl)
+
     def get_num_for_p(self, p, styles_cache):
         """
         Returns list item for the given paragraph.

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -149,6 +149,18 @@ class CT_Numbering(BaseOxmlElement):
         abstractNum_el = self.get_abstractNum(numId)
         return abstractNum_el.get_lvl(ilvl)
 
+    def get_lvl_from_properties(self, p):
+        """
+        Gets the formatting based on current paragraph indentation level.
+        """
+        numPr = p.pPr.numPr
+        if numPr is None:
+            return numPr
+        ilvl, numId = numPr.ilvl, numPr.numId.val
+        ilvl = ilvl.val if ilvl is not None else 0
+        abstractNum_el = self.get_abstractNum(numId)
+        return abstractNum_el.get_lvl(ilvl)
+
     def get_num_for_p(self, p, styles_cache):
         """
         Returns list item for the given paragraph.

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -146,18 +146,17 @@ class CT_Numbering(BaseOxmlElement):
         level from direct paragraph formating is used.
         """
         try:
-            if styles_cache:
-                numPr = p.pPr.get_style_numPr(styles_cache)
-            else:
-                numPr = p.pPr.numPr
+            numPr  = p.pPr.get_style_numPr(styles_cache) if styles_cache else p.pPr.numPr
+
             if numPr is None:
                 raise AttributeError
+
+            ilvl, numId = numPr.ilvl, numPr.numId.val
+            ilvl = ilvl.val if ilvl is not None else 0
+            abstractNum_el = self.get_abstractNum(numId)
+            return abstractNum_el.get_lvl(ilvl)
         except AttributeError:
             return None
-        ilvl, numId = numPr.ilvl, numPr.numId.val
-        ilvl = ilvl.val if ilvl is not None else 0
-        abstractNum_el = self.get_abstractNum(numId)
-        return abstractNum_el.get_lvl(ilvl)
 
     def get_num_for_p(self, p, styles_cache):
         """

--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -139,41 +139,21 @@ class CT_Numbering(BaseOxmlElement):
             if el.abstractNumId == abstractNum_id:
                 return el
 
-    def get_lvl_for_p(self, p, styles_cache):
+    def get_lvl_from_props(self, p, styles_cache=None):
         """
-        Gets the formatting based on current paragraph indentation level.
-        """
-        numPr = p.pPr.get_numPr(styles_cache)
-        ilvl, numId = numPr.ilvl, numPr.numId.val
-        ilvl = ilvl.val if ilvl is not None else 0
-        abstractNum_el = self.get_abstractNum(numId)
-        return abstractNum_el.get_lvl(ilvl)
-
-    def get_lvl_from_properties(self, p):
-        """
-        Gets the formatting based on current paragraph indentation level.
+        Gets the formatting based on current paragraph indentation level defined in paragraph styles.
+        If ``styles_cache`` is not None then level from style formating is fetched otherwise
+        level from direct paragraph formating is used.
         """
         try:
-            numPr = p.pPr.numPr
+            if styles_cache:
+                numPr = p.pPr.get_style_numPr(styles_cache)
+            else:
+                numPr = p.pPr.numPr
+            if numPr is None:
+                raise AttributeError
         except AttributeError:
             return None
-        if numPr is None:
-            return numPr
-        ilvl, numId = numPr.ilvl, numPr.numId.val
-        ilvl = ilvl.val if ilvl is not None else 0
-        abstractNum_el = self.get_abstractNum(numId)
-        return abstractNum_el.get_lvl(ilvl)
-
-    def get_lvl_from_style_properties(self, p, styles_cache):
-        """
-        Gets the formatting based on current paragraph indentation level.
-        """
-        try:
-            numPr = p.pPr.get_style_numPr(styles_cache)
-        except AttributeError:
-            return None
-        if numPr is None:
-            return numPr
         ilvl, numId = numPr.ilvl, numPr.numId.val
         ilvl = ilvl.val if ilvl is not None else 0
         abstractNum_el = self.get_abstractNum(numId)

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -67,6 +67,12 @@ class CT_P(BaseOxmlElement):
         """
         return numbering_el.get_lvl_from_properties(self)
 
+    def lvl_from_style_props(self, numbering_el, styles_cache):
+        """
+        Returns ``<w:lvl>`` element formatting for the current paragraph.
+        """
+        return numbering_el.get_lvl_from_style_properties(self, styles_cache)
+
     def number(self, numbering_el, styles_cache):
         """
         Returns numbering part of the paragraph if any, else returns None.

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -55,23 +55,17 @@ class CT_P(BaseOxmlElement):
                 continue
             self.remove(child)
 
-    def lvl(self, numbering_el, styles_cache):
+    def lvl_from_para_props(self, numbering_el):
         """
         Returns ``<w:lvl>`` element formatting for the current paragraph.
         """
-        return numbering_el.get_lvl_for_p(self, styles_cache)
-
-    def lvl_from_props(self, numbering_el):
-        """
-        Returns ``<w:lvl>`` element formatting for the current paragraph.
-        """
-        return numbering_el.get_lvl_from_properties(self)
+        return numbering_el.get_lvl_from_props(self)
 
     def lvl_from_style_props(self, numbering_el, styles_cache):
         """
-        Returns ``<w:lvl>`` element formatting for the current paragraph.
+        Returns ``<w:lvl>`` element formatting for the current paragraph style formatting.
         """
-        return numbering_el.get_lvl_from_style_properties(self, styles_cache)
+        return numbering_el.get_lvl_from_props(self, styles_cache)
 
     def number(self, numbering_el, styles_cache):
         """

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -57,13 +57,15 @@ class CT_P(BaseOxmlElement):
 
     def lvl_from_para_props(self, numbering_el):
         """
-        Returns ``<w:lvl>`` element formatting for the current paragraph.
+        Returns ``<w:lvl>`` numbering level paragraph formatting for the current paragraph using
+        numbering linked via the direct paragraph formatting.
         """
         return numbering_el.get_lvl_from_props(self)
 
     def lvl_from_style_props(self, numbering_el, styles_cache):
         """
-        Returns ``<w:lvl>`` element formatting for the current paragraph style formatting.
+        Returns ``<w:lvl>`` numbering level paragraph formatting for the current paragraph using
+        numbering linked via the paragraph style formatting.
         """
         return numbering_el.get_lvl_from_props(self, styles_cache)
 

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -61,6 +61,12 @@ class CT_P(BaseOxmlElement):
         """
         return numbering_el.get_lvl_for_p(self, styles_cache)
 
+    def lvl_from_props(self, numbering_el):
+        """
+        Returns ``<w:lvl>`` element formatting for the current paragraph.
+        """
+        return numbering_el.get_lvl_from_properties(self)
+
     def number(self, numbering_el, styles_cache):
         """
         Returns numbering part of the paragraph if any, else returns None.

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -104,6 +104,12 @@ class CT_PPr(BaseOxmlElement):
             except (KeyError, AttributeError):
                 return None
 
+    def get_style_numPr(self, styles_cache):
+        try:
+            return styles_cache[self.pStyle.val].pPr.numPr
+        except (KeyError, AttributeError):
+            return None
+
     @property
     def ind_left(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -469,10 +469,10 @@ class Paragraph(Parented):
 
         def apply_formatting(source, first_line_indent=None, left_indent=None):
             if source:
-                if source.first_line_indent is not None:
-                    first_line_indent = source.first_line_indent
-                if source.left_indent is not None:
-                    left_indent = source.left_indent
+                if getattr(source, 'first_line_indent', None) is not None:
+                    first_line_indent = getattr(source, 'first_line_indent')
+                if getattr(source, 'left_indent', None) is not None:
+                    left_indent = getattr(source, 'left_indent')
             return first_line_indent, left_indent
 
         # apply paragraph styles by priority (from lowest to highest)

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -489,58 +489,54 @@ class Paragraph(Parented):
         if left_indent is not None:
             left_indent = round(left_indent.inches, 2)
 
-        if self.para_numbering_format or self.style_numbering_format:
-            indent = first_line_indent or 0
-            indent += left_indent or 0
-        else:
-            # If para is not numbered we shall calculate using tabs and tab stops
-            DEFAULT_TAB_STOP = 0.5
-            tab_count = 0
+        # If para is not numbered we shall calculate using tabs and tab stops
+        DEFAULT_TAB_STOP = 0.5
+        tab_count = 0
 
-            # Calculate the base first line indent and para left indent.
-            left_indent = left_indent or 0
-            indent = first_line_indent = (first_line_indent or 0) + left_indent
+        # Calculate the base first line indent and para left indent.
+        left_indent = left_indent or 0
+        indent = first_line_indent = (first_line_indent or 0) + left_indent
 
-            # Find out the number of tabs at the beginning of the paragraph.
-            # Ignore regular spaces.
-            tab_count = self.text[:len(self.text) - len(self.text.lstrip())].count('\t')
+        # Find out the number of tabs at the beginning of the paragraph.
+        # Ignore regular spaces.
+        tab_count = self.text[:len(self.text) - len(self.text.lstrip())].count('\t')
 
-            if tab_count:
+        if tab_count:
 
-                # Get tab stops but only those to the right of first line indent as the previous
-                # don't affect the indentation.
-                tab_stops = [ts for ts in get_tabstops(self) if ts > first_line_indent]
+            # Get tab stops but only those to the right of first line indent as the previous
+            # don't affect the indentation.
+            tab_stops = [ts for ts in get_tabstops(self) if ts > first_line_indent]
 
-                # If the first line indent is left of the paragraph indent, first tab will tab to
-                # the paragraph indent.
-                if first_line_indent < left_indent:
-                    tab_stops.append(left_indent)
+            # If the first line indent is left of the paragraph indent, first tab will tab to
+            # the paragraph indent.
+            if first_line_indent < left_indent:
+                tab_stops.append(left_indent)
 
-                # Eliminate duplicates and sort.
-                tab_stops = list(sorted(set(tab_stops)))
+            # Eliminate duplicates and sort.
+            tab_stops = list(sorted(set(tab_stops)))
 
-                if len(tab_stops) >= tab_count:
-                    # We have enough tab stops to cover all tab chars.
-                    if tab_stops:
-                        indent = tab_stops[tab_count - 1]
+            if len(tab_stops) >= tab_count:
+                # We have enough tab stops to cover all tab chars.
+                if tab_stops:
+                    indent = tab_stops[tab_count - 1]
 
-                else:
-                    if tab_stops:
-                        indent = tab_stops[-1]
-                        tab_count -= len(tab_stops)
+            else:
+                if tab_stops:
+                    indent = tab_stops[-1]
+                    tab_count -= len(tab_stops)
 
-                    # It's easier to calculate in whole tab stop indents instead of inches
-                    indent *= (1 / DEFAULT_TAB_STOP)
+                # It's easier to calculate in whole tab stop indents instead of inches
+                indent *= (1 / DEFAULT_TAB_STOP)
 
-                    # Let's round up to the first tab char indent. If already rounded add one.
-                    tab_count -= 1
-                    indent = math.ceil(indent) if not indent.is_integer() else indent + 1
+                # Let's round up to the first tab char indent. If already rounded add one.
+                tab_count -= 1
+                indent = math.ceil(indent) if not indent.is_integer() else indent + 1
 
-                    # The remaining tab chars just adds whole indents.
-                    indent += tab_count
+                # The remaining tab chars just adds whole indents.
+                indent += tab_count
 
-                    # Scale back to inches
-                    indent /= (1 / DEFAULT_TAB_STOP)
+                # Scale back to inches
+                indent /= (1 / DEFAULT_TAB_STOP)
 
         return Inches(indent)
 

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -223,6 +223,13 @@ class Paragraph(Parented):
             return self._lvl
 
     @property
+    def lvl_from_props(self):
+        """
+        Gets the `lvl` element based on the indentation index.
+        """
+        return self._p.lvl_from_props(self.part.numbering_part._element)
+
+    @property
     def numbering_format(self):
         """
         Returns |ParagraphFormat| object based on the formatting for the given
@@ -230,6 +237,13 @@ class Paragraph(Parented):
         """
         return ParagraphFormat(self.lvl) if self.lvl is not None else None
 
+    @property
+    def numbering_format_props(self):
+        """
+        Returns |ParagraphFormat| object based on the formatting for the given
+        level of the numbered list.
+        """
+        return ParagraphFormat(self.lvl_from_props) if self.lvl_from_props is not None else None
     @property
     def paragraph_format(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -230,6 +230,13 @@ class Paragraph(Parented):
         return self._p.lvl_from_props(self.part.numbering_part._element)
 
     @property
+    def lvl_from_style_props(self):
+        """
+        Gets the `lvl` element based on the indentation index.
+        """
+        return self._p.lvl_from_style_props(self.part.numbering_part._element, self.part.cached_styles)
+
+    @property
     def numbering_format(self):
         """
         Returns |ParagraphFormat| object based on the formatting for the given
@@ -244,6 +251,15 @@ class Paragraph(Parented):
         level of the numbered list.
         """
         return ParagraphFormat(self.lvl_from_props) if self.lvl_from_props is not None else None
+
+    @property
+    def numbering_format_style(self):
+        """
+        Returns |ParagraphFormat| object based on the formatting for the given
+        level of the numbered list.
+        """
+        return ParagraphFormat(self.lvl_from_style_props) if self.lvl_from_style_props is not None else None
+
     @property
     def paragraph_format(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -212,7 +212,8 @@ class Paragraph(Parented):
     @property
     def lvl_from_para_props(self):
         """
-        Gets the ``<w:lvl>`` element from paragraph properties based on the indentation index.
+        Returns ``<w:lvl>`` numbering level paragraph formatting for the current paragraph using
+        numbering linked via the direct paragraph formatting.
         """
         if self._lvl_from_para_props is None:
             try:
@@ -224,7 +225,8 @@ class Paragraph(Parented):
     @property
     def lvl_from_style_props(self):
         """
-        Gets the ``<w:lvl>`` element from style's paragraph properties based on the indentation index.
+        Returns ``<w:lvl>`` numbering level paragraph formatting for the current paragraph using
+        numbering linked via the paragraph style formatting.
         """
         if self._lvl_from_style_props is None:
             try:
@@ -475,12 +477,17 @@ class Paragraph(Parented):
                     left_indent = getattr(source, 'left_indent')
             return first_line_indent, left_indent
 
-        # apply paragraph styles by priority (from lowest to highest)
+        # Apply paragraph styles by priority (from lowest to highest).
+        # Formatting from the base style has the lowest priority.
         first_line_indent = get_base_style_attr(self.style, 'first_line_indent')
         left_indent = get_base_style_attr(self.style, 'left_indent')
+        # Next, we apply formatting from numbering properties defined in paragraph style.
         first_line_indent, left_indent = apply_formatting(self.style_numbering_format, first_line_indent, left_indent)
+        # Then formatting from paragraph style.
         first_line_indent, left_indent = apply_formatting(self.style.paragraph_format, first_line_indent, left_indent)
+        # Next, formatting from numbering properties defined in direct paragraph properties is applied.
         first_line_indent, left_indent = apply_formatting(self.para_numbering_format, first_line_indent, left_indent)
+        # Finally, we apply formatting from direct paragraph formatting.
         first_line_indent, left_indent = apply_formatting(self.paragraph_format, first_line_indent, left_indent)
 
         # Get explicitly set indentation

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -483,19 +483,28 @@ class Paragraph(Parented):
             _inner_get_tabstops(para)
             return tabstops
 
+        def apply_formatting(source, first_line_indent=None, left_indent=None):
+            if source:
+                first_line_indent = source.first_line_indent if source.first_line_indent is not None \
+                    else first_line_indent
+                left_indent = source.left_indent if source.left_indent is not None \
+                    else left_indent
+            return first_line_indent, left_indent
+
+        first_line_indent, left_indent = apply_formatting(self.numbering_format_style)
+        first_line_indent, left_indent = apply_formatting(self.style.paragraph_format, first_line_indent, left_indent)
+        first_line_indent, left_indent = apply_formatting(self.numbering_format_props, first_line_indent, left_indent)
+        first_line_indent, left_indent = apply_formatting(self.paragraph_format, first_line_indent, left_indent)
+
         # Get explicitly set indentation
-        first_line_indent = self.paragraph_format.first_line_indent
         if first_line_indent is not None:
             first_line_indent = round(first_line_indent.inches, 2)
-        left_indent = self.paragraph_format.left_indent
         if left_indent is not None:
             left_indent = round(left_indent.inches, 2)
 
         if self.numbering_format:
-            indent = first_line_indent if first_line_indent is not None \
-                 else self.numbering_format.first_line_indent.inches
-            indent += left_indent if left_indent is not None \
-                else self.numbering_format.left_indent.inches
+            indent = first_line_indent or 0
+            indent += left_indent or 0
         else:
             # If para is not numbered we shall calculate using tabs and tab stops
             DEFAULT_TAB_STOP = 0.5


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

Fixed left indentation bug by refactoring method that returns left indentation. New implementation takes into account priority while applying styles and resolves the bug.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
