### PR TITLE
Feature: Alt text support

### DIFF
--- a/docx/oxml/shape.py
+++ b/docx/oxml/shape.py
@@ -109,6 +109,7 @@ class CT_NonVisualDrawingProps(BaseOxmlElement):
     """
     id = RequiredAttribute('id', ST_DrawingElementId)
     name = RequiredAttribute('name', XsdString)
+    descr = OptionalAttribute('descr', XsdString)
 
 
 class CT_NonVisualPictureProperties(BaseOxmlElement):

--- a/docx/parts/image.py
+++ b/docx/parts/image.py
@@ -23,6 +23,7 @@ class ImagePart(Part):
     def __init__(self, partname, content_type, blob, image=None):
         super(ImagePart, self).__init__(partname, content_type, blob)
         self._image = image
+        self._descr = None
 
     @property
     def default_cx(self):

--- a/docx/parts/image.py
+++ b/docx/parts/image.py
@@ -87,3 +87,11 @@ class ImagePart(Part):
         SHA1 hash digest of the blob of this image part.
         """
         return hashlib.sha1(self._blob).hexdigest()
+
+    @property
+    def descr(self):
+        return self._descr
+
+    @descr.setter
+    def descr(self, desc):
+        self._descr = desc

--- a/docx/parts/image.py
+++ b/docx/parts/image.py
@@ -23,7 +23,7 @@ class ImagePart(Part):
     def __init__(self, partname, content_type, blob, image=None):
         super(ImagePart, self).__init__(partname, content_type, blob)
         self._image = image
-        self._descr = None
+        self._docPr = None
 
     @property
     def default_cx(self):
@@ -91,8 +91,8 @@ class ImagePart(Part):
 
     @property
     def descr(self):
-        return self._descr
+        return self._docPr.descr
 
     @descr.setter
-    def descr(self, desc):
-        self._descr = desc
+    def descr(self, text):
+        self._docPr.descr = text

--- a/docx/parts/image.py
+++ b/docx/parts/image.py
@@ -23,7 +23,6 @@ class ImagePart(Part):
     def __init__(self, partname, content_type, blob, image=None):
         super(ImagePart, self).__init__(partname, content_type, blob)
         self._image = image
-        self._docPr = None
 
     @property
     def default_cx(self):

--- a/docx/shape.py
+++ b/docx/shape.py
@@ -103,9 +103,9 @@ class InlineShape(object):
         self._inline.graphic.graphicData.pic.spPr.cx = cx
 
     @property
-    def alt_text(self):
+    def descr(self):
         return self._inline.docPr.descr
 
-    @alt_text.setter
-    def alt_text(self, text):
+    @descr.setter
+    def descr(self, text):
         self._inline.docPr.descr = text

--- a/docx/shape.py
+++ b/docx/shape.py
@@ -101,3 +101,11 @@ class InlineShape(object):
     def width(self, cx):
         self._inline.extent.cx = cx
         self._inline.graphic.graphicData.pic.spPr.cx = cx
+
+    @property
+    def alt_text(self):
+        return self._inline.docPr.descr
+
+    @alt_text.setter
+    def alt_text(self, text):
+        self._inline.docPr.descr = text

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -188,6 +188,7 @@ class Paragraph(Parented):
                 parts.append(doc.part.related_parts[b.embed])
 
         for idx, part in enumerate(parts):
-            part.descr = docPrs[idx].descr
+            if not part.descr:
+                part.descr = docPrs[idx].descr
 
         return parts

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -164,8 +164,9 @@ class Paragraph(Parented):
         blips = [drawing.xpath(".//*[local-name() = 'blip']")[0]
                  for drawing in drawings]
 
-        docPrs = [drawing.xpath(".//*[local-name() = 'docPr']")[0]
-                  for drawing in drawings]
+        inlines = []
+        for drawing in drawings:
+            inlines.extend(drawing.iterchildren())
 
         for b in blips:
             if b.link:
@@ -188,7 +189,6 @@ class Paragraph(Parented):
                 parts.append(doc.part.related_parts[b.embed])
 
         for idx, part in enumerate(parts):
-            if not part.descr:
-                part.descr = docPrs[idx].descr
+            part._docPr = inlines[idx].docPr
 
         return parts

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -164,6 +164,8 @@ class Paragraph(Parented):
         blips = [drawing.xpath(".//*[local-name() = 'blip']")[0]
                  for drawing in drawings]
 
+        docPrs = [drawing.xpath(".//*[local-name() = 'docPr']")[0]
+                  for drawing in drawings]
 
         for b in blips:
             if b.link:
@@ -184,5 +186,8 @@ class Paragraph(Parented):
                         pass
             elif b.embed:
                 parts.append(doc.part.related_parts[b.embed])
+
+        for idx, part in enumerate(parts):
+            part.descr = docPrs[idx].descr
 
         return parts


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

Extend `ImagePart` and `InlineShape` to support alt text.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
