### PR TITLE
fix: `_docPr` AttributeError

### DIFF
--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -189,6 +189,7 @@ class Paragraph(Parented):
                 parts.append(doc.part.related_parts[b.embed])
 
         for idx, part in enumerate(parts):
-            part._docPr = inlines[idx].docPr
+            if hasattr(part, '_docPr'):
+                part._docPr = inlines[idx].docPr
 
         return parts


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

Not all images have document properties defined, so add check to handle that edge case.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
