### PR TITLE
fix: add basic support for `<wp:anchor>`

### DIFF
--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -134,6 +134,7 @@ register_element_cls('pic:spPr',      CT_ShapeProperties)
 register_element_cls('wp:docPr',      CT_NonVisualDrawingProps)
 register_element_cls('wp:extent',     CT_PositiveSize2D)
 register_element_cls('wp:inline',     CT_Inline)
+register_element_cls('wp:anchor',     CT_Inline)
 
 from .styles import CT_LatentStyles, CT_LsdException, CT_Style, CT_Styles  # noqa
 register_element_cls('w:basedOn',        CT_String)


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

Since both `<wp:inline>` and `<wp:anchor>`
have the same base attributes register `<wp:anchor>`
as `CT_Inline` for basic support.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
