### PR TITLE
fix: reset numbering implementation

### DIFF
--- a/docx/oxml/numbering.py
+++ b/docx/oxml/numbering.py
@@ -178,15 +178,23 @@ class CT_Numbering(BaseOxmlElement):
                     if prev_p_numId == 0:
                         continue
                     prev_p_pStyle = prev_p.pPr.pStyle
-                    if prev_p_ilvl < p_ilvl and (prev_p_numId == p_numId or pStyle.val == prev_p_pStyle.val or
+                    if prev_p_ilvl < p_ilvl and (prev_p_numId == p_numId or
                                          (prev_p_pStyle is not None and prev_p_pStyle.val in linked_styles)):
                         break
-                    if prev_p_ilvl == p_ilvl and (prev_p_numId == p_numId or pStyle.val == prev_p_pStyle.val or prev_p_pStyle.val in linked_styles):
+                    if prev_p_ilvl == p_ilvl and (prev_p_numId == p_numId or prev_p_pStyle.val in linked_styles):
                         yield prev_p_numId
+                    # para `p` that has only style defined which is same as the `prev_p` style
+                    # should be counted even though they have different `numId`s.
+                    if prev_p_ilvl == p_ilvl and prev_p_numId != p_numId:
+                        if p.pPr.numPr is None and prev_p.pPr.pStyle.val == pStyle.val:
+                            startOverride = get_start_override(prev_p_numId)
+                            if startOverride > 1:
+                                yield prev_p_numId
+                            else:
+                                yield p_numId
+                            break
                 except AttributeError:
                     continue
-                except StopIteration:
-                    break
 
         def count_same_numIds(preceding_paragraphs_numIds, numId, num):
             """


### PR DESCRIPTION
- Removed check if styles of two paragraphs have the same style
since it was redundant.
- Add check if starting paragraph has just style defined then it
should "follow" preceding paragraph. Meaning that it should
increment the counter even though they have different `numId`s.

## Description (e.g. "Related to ...", "Closes ...", etc.)



## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
