### PR TITLE
feat: add support for `w:sym` element

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.19'
+__version__ = '0.8.10.20'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -275,3 +275,6 @@ register_element_cls('w:cr', CT_Cr)
 register_element_cls('w:r',  CT_R)
 register_element_cls('w:t',  CT_Text)
 register_element_cls('w:fldChr', CT_FldChar)
+
+from .text.symbol import CT_Sym
+register_element_cls('w:sym', CT_Sym)

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -41,6 +41,7 @@ class CT_R(BaseOxmlElement):
     bookmarkEnd = ZeroOrMore("w:bookmarkEnd")
     fldChar = ZeroOrMore('w:fldChar')
     instrText = ZeroOrMore('w:instrText')
+    sym = ZeroOrMore('w:sym')
 
     def _insert_rPr(self, rPr):
         self.insert(0, rPr)
@@ -112,6 +113,8 @@ class CT_R(BaseOxmlElement):
                 text += '\r'
             elif child.tag == qn('w:noBreakHyphen'):
                 text += '-'
+            elif child.tag == qn('w:sym'):
+                text += child.readSymbol
         return text
 
     @text.setter

--- a/docx/oxml/text/symbol.py
+++ b/docx/oxml/text/symbol.py
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+"""
+Custom element classes related to text symbols (CT_Sym).
+"""
+
+from ..xmlchemy import (
+    BaseOxmlElement, OptionalAttribute
+)
+from ..simpletypes import (
+    ST_String
+)
+from warnings import warn
+
+# for a specific font map most used symbols to appropriate character
+font_to_char_map = {
+    'WP TypographicSymbols': {
+        '0027': "§",
+        '0040': "”",
+        '0038': "©",
+        '003D': "’",
+        '0041': "“",
+        '0042': "–",
+        '0043': "—"
+    },
+}
+
+class CT_Sym(BaseOxmlElement):
+    """
+    ``<w:sym>`` element, containing the symbol.
+    """
+
+    # We are using type `ST_String` because we have that implemented, the official type should be `ST_ShortHexNumber`, maybe in the future add support for that type
+    char = OptionalAttribute('w:char', ST_String)
+    font = OptionalAttribute('w:font', ST_String)
+
+    @property
+    def readSymbol(self):
+        """
+        Returns the symbol value if the font is supported otherwise returns the Unicode value with a warning.
+        """
+        try:
+            symbol = font_to_char_map[self.font][self.char.upper()]
+        except KeyError:
+            msg = f"Symbol <{self.char}> is not supported in font '{self.font}', fallback to Uniode value"
+            warn(msg, UserWarning, stacklevel=2)
+            symbol = r"\u"+self.char
+
+        return symbol
+


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

Symbol element is used by WordPerfect for some special characters


## Code review checklist

- [x] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [x] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
