### PR TITLE
fix: ignore noBreakHyphen when part of fldChar

### DIFF
--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -97,6 +97,11 @@ class CT_R(BaseOxmlElement):
             elif child.tag in (qn('w:br'), qn('w:cr')):
                 text += '\n'
             elif child.tag == qn('w:noBreakHyphen'):
+                # if noBreakHyphen is in the same run as instrText then
+                # it is part of fldChar and should be ingored since
+                # it represents part of hidden text
+                if qn('w:instrText') in [ch.tag for ch in self]:
+                    continue
                 text += '-'
         return text
 

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -100,9 +100,12 @@ class CT_R(BaseOxmlElement):
                 # if noBreakHyphen is in the same run as instrText then
                 # it is part of fldChar and should be ingored since
                 # it represents part of hidden text
-                if qn('w:instrText') in [ch.tag for ch in self]:
-                    continue
-                text += '-'
+                has_instr_text = False
+                for _ in self.iterchildren(tag=qn('w:instrText')):
+                    has_instr_text = True
+                    break
+                if not has_instr_text:
+                    text += '-'
         return text
 
     @text.setter


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

When working with WordPerfect documents we've encountered trailing hyphens in some of the paragraphs.
After some inspection we've figured that those hyphens are actually `w:noBreakHyphen` that are part of complex field group ([Fields documentation](http://www.officeopenxml.com/WPfields.php)).

WordPerfect documents had complex fields that were used to create table of content references. Those fields contained `w:noBreakHyphen` in them. That hyphen was then shown as part of paragraphs text.

In order to fully fix this issue, a proper support for complex fields needs to be implemented. Up until then, this simple solution is proposed that should work in most cases. This solution ignores `w:noBreakHyphen` when it's part of the same run as `w:instrText`. `w:instrText` is usually only found in complex fields and is used to give instruction code for them ([w:instrText](http://www.datypic.com/sc/ooxml/e-w_instrText-1.html)). Downside of this solution is that `w:instrText` can be found outside complex fields and in those situation it's ignored, so then we should not ignore `w:noBreakHyphen`. However, those situations should not happen often.


## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
