### PR TITLE
Revert "Merge pull request #109 from openlawlibrary/fix/hidden-text-tc"

### DIFF
--- a/docx/oxml/exceptions.py
+++ b/docx/oxml/exceptions.py
@@ -14,9 +14,3 @@ class InvalidXmlError(XmlchemyError):
     Raised when invalid XML is encountered, such as on attempt to access a
     missing required child element
     """
-
-class HiddenTextTC(Exception):
-    """
-    Raised when parsing hidden text that represents table content.
-    This text is used as a link to Table of Contents, and shouldn't be return as viewable text.
-    """

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -4,7 +4,6 @@
 Custom element classes related to text runs (CT_R).
 """
 
-from docx.oxml.exceptions import HiddenTextTC
 from ..ns import qn
 from ..simpletypes import ST_BrClear, ST_BrType
 from ..xmlchemy import (
@@ -99,10 +98,6 @@ class CT_R(BaseOxmlElement):
                 text += '\t'
             elif child.tag in (qn('w:br'), qn('w:cr')):
                 text += '\n'
-            elif child.tag == qn('w:instrText'):
-                if child.text.lower().startswith(('tc \\l1 "', 'tc \\l2 "', 'tc \\l3 "', 'tc \\l4 "')):
-                    #paragraph form this run continues with `hidden text` for Table content
-                    raise HiddenTextTC(text)
         return text
 
     @text.setter

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -12,7 +12,6 @@ from ..enum.style import WD_STYLE_TYPE
 from .parfmt import ParagraphFormat
 from .run import Run
 from ..shared import Parented
-from ..oxml.exceptions import HiddenTextTC
 
 
 class Paragraph(Parented):
@@ -138,11 +137,8 @@ class Paragraph(Parented):
         run-level formatting, such as bold or italic, is removed.
         """
         text = ''
-        try:
-            for run in self.runs:
-                text += run.text
-        except HiddenTextTC as tc:
-            text += str(tc)
+        for run in self.runs:
+            text += run.text
         return text
 
     @text.setter


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

This reverts PR that introduced hidden text support for fields.

The problem with the fix is that it relied on exceptions and in order for it to fully work all usages of `run.text` should be wrapped with try/except block. This caused some leaky exceptions that weren't handled.

A new fix is proposed in #111.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
