### PR TITLE
Fix: ignore hyphen in fields release

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.20'
+__version__ = '0.8.10.22'
 
 
 # register custom Part classes with opc package reader

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.21'
+__version__ = '0.8.10.20'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/exceptions.py
+++ b/docx/oxml/exceptions.py
@@ -14,9 +14,3 @@ class InvalidXmlError(XmlchemyError):
     Raised when invalid XML is encountered, such as on attempt to access a
     missing required child element
     """
-
-class HiddenTextTC(Exception):
-    """
-    Raised when parsing hidden text that represents table content.
-    This text is used as a link to Table of Contents, and shouldn't be return as viewable text.
-    """

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -4,7 +4,6 @@
 Custom element classes related to text runs (CT_R).
 """
 
-from docx.oxml.exceptions import HiddenTextTC
 from ..ns import qn
 from ..simpletypes import ST_BrClear, ST_BrType
 from ..xmlchemy import (
@@ -110,10 +109,6 @@ class CT_R(BaseOxmlElement):
                 text += '\t'
             elif child.tag == qn('w:br'):
                 text += '\n'
-            elif child.tag == qn('w:instrText'):
-                if child.text.lower().startswith(('tc \\l1 "', 'tc \\l2 "', 'tc \\l3 "', 'tc \\l4 "')):
-                    #paragraph form this run continues with `hidden text` for Table content
-                    raise HiddenTextTC(text)
             elif child.tag == qn('w:cr'):
                 text += '\r'
             elif child.tag == qn('w:noBreakHyphen'):

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -115,9 +115,12 @@ class CT_R(BaseOxmlElement):
                 # if noBreakHyphen is in the same run as instrText then
                 # it is part of fldChar and should be ingored since
                 # it represents part of hidden text
-                if qn('w:instrText') in [ch.tag for ch in self]:
-                    continue
-                text += '-'
+                has_instr_text = False
+                for _ in self.iterchildren(tag=qn('w:instrText')):
+                    has_instr_text = True
+                    break
+                if not has_instr_text:
+                    text += '-'
             elif child.tag == qn('w:sym'):
                 text += child.readSymbol
         return text

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -112,6 +112,11 @@ class CT_R(BaseOxmlElement):
             elif child.tag == qn('w:cr'):
                 text += '\r'
             elif child.tag == qn('w:noBreakHyphen'):
+                # if noBreakHyphen is in the same run as instrText then
+                # it is part of fldChar and should be ingored since
+                # it represents part of hidden text
+                if qn('w:instrText') in [ch.tag for ch in self]:
+                    continue
                 text += '-'
             elif child.tag == qn('w:sym'):
                 text += child.readSymbol

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -15,7 +15,6 @@ import pathlib
 from ..enum.style import WD_STYLE_TYPE
 from .parfmt import ParagraphFormat
 from .run import Run
-from ..oxml.exceptions import HiddenTextTC
 from ..shared import Parented, Length, lazyproperty, Inches, cache, bust_cache
 from ..oxml.ns import nsmap
 from docx.bookmark import BookmarkParent
@@ -396,14 +395,10 @@ class Paragraph(Parented, BookmarkParent):
     @property
     @cache
     def run_text(self):
-        text = ''
         if self.runs:
-            try:
-                for run in self.runs:
-                    text += run.text
-            except HiddenTextTC as tc:
-                text += str(tc)
-        return text
+            return ''.join(r.text for r in self.runs)
+        else:
+            return ''
 
     def set_li_lvl(self, styles, prev, ilvl):
         """


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

This PR merges work on:
- feature fields branch that reverts previous fix
- adds a fix to feature no break hyphen

This PR also bumps new version and after merging a new release will be created.

Related to: https://github.com/openlawlibrary/python-docx/pull/111
Related to: https://github.com/openlawlibrary/python-docx/pull/112

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
