### PR TITLE
feat: initial support for complex field char `w:fldChar`

### DIFF
--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -246,4 +246,4 @@ from .text.run import CT_Br, CT_R, CT_Text, CT_FldChar
 register_element_cls('w:br', CT_Br)
 register_element_cls('w:r',  CT_R)
 register_element_cls('w:t',  CT_Text)
-register_element_cls('w:fldChr', CT_FldChar)
+register_element_cls('w:fldChar', CT_FldChar)

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -96,6 +96,9 @@ class CT_R(BaseOxmlElement):
                     if child.fldCharType == 'begin':
                         CT_FldChar.numOfNestedFldChar += 1
                     else:
+                        # `w:fldChar` stores instruction text from `w:fldCharType='begin'`
+                        # to `w:fldCharType='separate'` if 'separate' exists, if not then
+                        # until `w:fldCharType='end'`.
                         CT_FldChar.numOfNestedFldChar -= 1
         else:
             for child in self:

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -5,9 +5,9 @@ Custom element classes related to text runs (CT_R).
 """
 
 from ..ns import qn
-from ..simpletypes import ST_BrClear, ST_BrType
+from ..simpletypes import ST_BrClear, ST_BrType, ST_String
 from ..xmlchemy import (
-    BaseOxmlElement, OptionalAttribute, ZeroOrMore, ZeroOrOne
+    BaseOxmlElement, OptionalAttribute, ZeroOrMore, ZeroOrOne, RequiredAttribute
 )
 
 
@@ -90,14 +90,25 @@ class CT_R(BaseOxmlElement):
         equivalent.
         """
         text = ''
-        for child in self:
-            if child.tag == qn('w:t'):
-                t_text = child.text
-                text += t_text if t_text is not None else ''
-            elif child.tag == qn('w:tab'):
-                text += '\t'
-            elif child.tag in (qn('w:br'), qn('w:cr')):
-                text += '\n'
+        if CT_FldChar.numOfNestedFldChar > 0:
+            for child in self:
+                if child.tag == qn('w:fldChar'):
+                    if child.fldCharType == 'begin':
+                        CT_FldChar.numOfNestedFldChar += 1
+                    else:
+                        CT_FldChar.numOfNestedFldChar -= 1
+        else:
+            for child in self:
+                if child.tag == qn('w:t'):
+                    t_text = child.text
+                    text += t_text if t_text is not None else ''
+                elif child.tag == qn('w:tab'):
+                    text += '\t'
+                elif child.tag in (qn('w:br'), qn('w:cr')):
+                    text += '\n'
+                elif child.tag == qn('w:fldChar'):
+                    if child.fldCharType == 'begin':
+                        CT_FldChar.numOfNestedFldChar += 1
         return text
 
     @text.setter
@@ -115,9 +126,12 @@ class CT_FldChar(BaseOxmlElement):
     """
     ``<w:fldChr>`` element, containing properties related to field.
     """
+    fldCharType = RequiredAttribute('w:fldCharType', ST_String)
     fldData = ZeroOrOne('w:fldData')
     ffData = ZeroOrOne('w:ffData')
     numberingChange = ZeroOrOne('w:numberingChange')
+    # used to count/determent nested complex field characters tag `w:fldChar`
+    numOfNestedFldChar = 0
 
 class _RunContentAppender(object):
     """


### PR DESCRIPTION
## Description

- Baseic support for complex field char `w:fldChar`, it ignores all text runs in between `w:fldChar` tags of type `begin` and (`end` or `separate`).

Closes: [#4393](https://github.com/openlawlibrary/platform/issues/4393)

> *NOTE:* when this PR is merge, then a new PR will be created for branch `merge-all`

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
