### PR TITLE
Tibor/merge all alignment

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.26'
+__version__ = '0.8.10.27'
 
 
 # register custom Part classes with opc package reader

--- a/docx/enum/text.py
+++ b/docx/enum/text.py
@@ -33,10 +33,16 @@ class WD_PARAGRAPH_ALIGNMENT(XmlEnumeration):
             'LEFT', 0, 'left', 'Left-aligned'
         ),
         XmlMappedEnumMember(
+            'LEFT', 0, 'start', 'Left-aligned'
+        ),
+        XmlMappedEnumMember(
             'CENTER', 1, 'center', 'Center-aligned.'
         ),
         XmlMappedEnumMember(
             'RIGHT', 2, 'right', 'Right-aligned.'
+        ),
+        XmlMappedEnumMember(
+            'RIGHT', 2, 'end', 'Right-aligned'
         ),
         XmlMappedEnumMember(
             'JUSTIFY', 3, 'both', 'Fully justified.'


### PR DESCRIPTION
## Description

- add alias for right/left paragraph alignment as end/start
- upgraded python-docx version
- removed complex field char support
- restored noBreakHyphen fix for baltimore

Closes: [#4375](https://github.com/openlawlibrary/platform/issues/4375)

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
