### PR TITLE
fix: bust cache when clear para or add_run

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.27'
+__version__ = '0.8.10.28'
 
 
 # register custom Part classes with opc package reader

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -51,6 +51,7 @@ class Paragraph(Parented, BookmarkParent):
         footnote = document._add_footnote(new_fr_id)
         return footnote
 
+    @text_changing
     def add_run(self, text=None, style=None):
         """
         Append a run to this paragraph containing *text* and having character
@@ -154,6 +155,7 @@ class Paragraph(Parented, BookmarkParent):
     def alignment(self, value):
         self._p.alignment = value
 
+    @text_changing
     def clear(self):
         """
         Return this same paragraph after removing all its content.


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)



## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
