### PR TITLE
Merge all invalidate cache fix

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.28'
+__version__ = '0.8.10.29'
 
 
 # register custom Part classes with opc package reader

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -322,6 +322,7 @@ class Paragraph(Parented, BookmarkParent):
             return self._number
 
     @number.setter
+    @text_changing
     def number(self, new_number):
         self._number = new_number
 


### PR DESCRIPTION
## Description

Fix for invalidate cache.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
