### PR TITLE
Fix/aspose symbols

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.31'
+__version__ = '0.8.10.32'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -6,6 +6,7 @@ Custom element classes related to text runs (CT_R).
 
 from ..ns import qn
 from ..simpletypes import ST_BrClear, ST_BrType, ST_FldCharType
+from .symbol import convert_char_to_symbol
 from ..xmlchemy import (
     BaseOxmlElement, OptionalAttribute, ZeroOrMore, ZeroOrOne, RequiredAttribute
 )
@@ -140,6 +141,14 @@ class CT_R(BaseOxmlElement):
         for child in self:
             if child.tag == qn('w:t'):
                 t_text = child.text
+                try:
+                    if self.rPr.rFonts is not None and \
+                        len(t_text) == 1 and \
+                        self.rPr.rFonts.attrib['{'+self.nsmap['w']+'}ascii'] == 'WP TypographicSymbols':
+                        # this is an symbol mapping from aspose lib
+                            t_text = convert_char_to_symbol(t_text, 'WP TypographicSymbols')
+                except:
+                    pass
                 text += t_text if t_text is not None else ''
             elif child.tag == qn('w:tab'):
                 text += '\t'

--- a/docx/oxml/text/symbol.py
+++ b/docx/oxml/text/symbol.py
@@ -15,15 +15,29 @@ from warnings import warn
 # for a specific font map most used symbols to appropriate character
 font_to_char_map = {
     'WP TypographicSymbols': {
+        # font code symbol mapping
         '0027': "§",
         '0040': "”",
         '0038': "©",
         '003D': "’",
         '0041': "“",
         '0042': "–",
-        '0043': "—"
+        '0043': "—",
+        # aspose ascii char mapping
+        '\'': "§",
+        '@': "”",
+        'C': "©",
+        'A': "“",
+        '-': "–",
     },
 }
+
+def convert_char_to_symbol(char, font):
+    """
+    Returns the proper symbol based on the character/character code and the font style.
+    Throws an KeyError if the desired symbol is not mapped.
+    """
+    return font_to_char_map[font][char]
 
 class CT_Sym(BaseOxmlElement):
     """
@@ -40,7 +54,7 @@ class CT_Sym(BaseOxmlElement):
         Returns the symbol value if the font is supported otherwise returns the Unicode value with a warning.
         """
         try:
-            symbol = font_to_char_map[self.font][self.char.upper()]
+            symbol = convert_char_to_symbol(self.char.upper(), self.font)
         except KeyError:
             msg = f"Symbol <{self.char}> is not supported in font '{self.font}', fallback to Uniode value"
             warn(msg, UserWarning, stacklevel=2)


### PR DESCRIPTION
## Description

Fix for aspose symbol mapping

Closes: [#4642](https://github.com/openlawlibrary/platform/issues/4642)


## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
