### PR TITLE
Fix/symbols

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.33'
+__version__ = '0.8.10.34'
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/text/symbol.py
+++ b/docx/oxml/text/symbol.py
@@ -45,6 +45,12 @@ font_to_char_map = {
         '0066': '⅞',
         '006E': '—',
     },
+    'WP IconicSymbolsA': {
+        'F046': '☎',
+    },
+    'Symbol': {
+        'F0B0': '°',
+    },
     'WP Phonetic': {
         'F05F': 'C',
     }


### PR DESCRIPTION
## Description

Added missing symbols that are in use by Baltimore code
Bump version of python-docx

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
