### PR TITLE
footnotes fix

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.36'
+__version__ = '0.8.10.37'
 
 
 # register custom Part classes with opc package reader

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -181,6 +181,13 @@ class DocumentPart(BaseStoryPart):
         part if one is not present.
         """
         try:
+            # check if in document is used `footnoteReference`.
+            # If not then load the default footnote part.
+            # The footnote part xml remains after all the footnotes are deleted,
+            # so this check is to prevent loading of unused footnotes.
+            refs = self.document.element.xpath('//w:footnoteReference')
+            if len(refs) == 0:
+                raise KeyError
             return self.part_related_by(RT.FOOTNOTES)
         except KeyError:
             footnotes_part = FootnotesPart.default(self.package)


### PR DESCRIPTION
## Description

* Before accessing footnotes, check if the footnote references are in document.xml.
If not, then return the default footnote.xml part.
* New version of library

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
