### PR TITLE
fix: wrong ID when multiple fn/en in same para

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = '0.8.10.38'
+__version__ = '0.8.10.39'
 
 
 # register custom Part classes with opc package reader

--- a/docx/document.py
+++ b/docx/document.py
@@ -307,7 +307,7 @@ class Document(ElementProxy):
             else:
                 # This is the last footnote before the new footnote, so we use its
                 # value to determent the value of the new footnote.
-                new_fr_id = max(self.paragraphs[p_i]._p.footnote_reference_ids)+1
+                new_fr_id = max(new_fr_id, max(self.paragraphs[p_i]._p.footnote_reference_ids)+1)
                 break
         return new_fr_id
 
@@ -347,7 +347,7 @@ class Document(ElementProxy):
             else:
                 # This is the last endnote before the new endnote, so we use its
                 # value to determine the value of the new endnote.
-                new_er_id = max(self.paragraphs[p_i]._p.endnote_reference_ids)+1
+                new_er_id = max(new_er_id, max(self.paragraphs[p_i]._p.endnote_reference_ids)+1)
                 break
         return new_er_id
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", "Closes ...", etc.)

When a para already contained footnotes and a previous para also had footnotes, the ID calculated from the current para was unconditionally overwritten by the previous para's max ID + 1.

This caused duplicate reference IDs when two footnotes were in the same para. Uses max() to preserve the higher value derived from same para footnotes.

## Code review checklist

- [ ] Private platform tests at `core/tests/test_python-docx` are updated and passing
- [ ] If this change is going to be deployed on Cloudsmith after merge, python-docx version number should be increased 

[commit messages]: https://chris.beams.io/posts/git-commit/
